### PR TITLE
v1.2.1: map reliability, OAuth webhook flow, dreame hardening

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -27,3 +27,9 @@ CLAUDE.md
 .claudeignore
 
 .mi_session.json
+HA_XIAOMI_HOME_AUTH_MAP_REPORT.md
+ha_xiaomi_home/
+issues.md
+plan.md
+dreame-map.md
+test-fails.md

--- a/.gitignore
+++ b/.gitignore
@@ -33,3 +33,4 @@ issues.md
 plan.md
 dreame-map.md
 test-fails.md
+push-notes.md

--- a/.gitignore
+++ b/.gitignore
@@ -34,3 +34,4 @@ plan.md
 dreame-map.md
 test-fails.md
 push-notes.md
+.scratch/

--- a/custom_components/xiaomi_vac/__init__.py
+++ b/custom_components/xiaomi_vac/__init__.py
@@ -173,7 +173,8 @@ def _async_manage_oauth_issue(
 
 async def async_unload_entry(hass: HomeAssistant, entry: XiaomiConfigEntry) -> bool:
     """Unload a config entry."""
-    data = entry.runtime_data
+    # runtime_data is only assigned at the end of setup; guard never-loaded entries
+    data = getattr(entry, "runtime_data", None)
     if data is not None and data.mqtt is not None:
         await data.mqtt.async_stop()
     return await hass.config_entries.async_unload_platforms(entry, PLATFORMS)
@@ -190,6 +191,7 @@ async def _async_start_mqtt(
     Additive & optional per the plan: any missing OAuth field → no client, no
     error, existing behaviour intact.
     """
+    await _async_refresh_oauth_for_mqtt(hass, entry, force=False)
     data = entry.data
     required = (
         data.get(CONF_OAUTH_ACCESS_TOKEN),
@@ -206,8 +208,7 @@ async def _async_start_mqtt(
         return None
 
     async def _token_provider(force: bool) -> str:
-        if force:
-            await async_refresh_oauth_entry(hass, entry, force=True)
+        await _async_refresh_oauth_for_mqtt(hass, entry, force=force)
         return str(entry.data.get(CONF_OAUTH_ACCESS_TOKEN, ""))
 
     async def _on_message(message: MqttMessage) -> None:
@@ -232,6 +233,19 @@ async def _async_start_mqtt(
         _LOGGER.exception("Failed to start MIoT MQTT client — continuing without it")
         return None
     return client
+
+
+async def _async_refresh_oauth_for_mqtt(
+    hass: HomeAssistant, entry: XiaomiConfigEntry, *, force: bool
+) -> bool:
+    """Refresh OAuth for MQTT; keep stale tokens when a due-check refresh fails."""
+    try:
+        return await async_refresh_oauth_entry(hass, entry, force=force)
+    except Exception:  # noqa: BLE001
+        if force:
+            raise
+        _LOGGER.exception("MIoT OAuth proactive refresh failed; using stored token")
+        return False
 
 
 async def async_migrate_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:

--- a/custom_components/xiaomi_vac/cloud/connector.py
+++ b/custom_components/xiaomi_vac/cloud/connector.py
@@ -51,6 +51,7 @@ class XiaomiCloud:
         self.pass_token = None  # long-lived; used to renew the session
         # resumable-login scratch state
         self.captcha_image: bytes | None = None
+        self.login_error: str = ""  # Xiaomi's desc from the last failed login
         self._fields: dict = {}
         self._2fa_ctx: str | None = None
         self._lp_url: str | None = None
@@ -229,7 +230,8 @@ class XiaomiCloud:
         if j.get("notificationUrl"):
             self._start_email_2fa(j["notificationUrl"])
             return "2fa"
-        _LOGGER.error("Login failed: %s", j.get("desc") or j)
+        self.login_error = str(j.get("desc") or "")
+        _LOGGER.error("Xiaomi account sign-in rejected: %s", self.login_error or j)
         return "fail"
 
     def login(

--- a/custom_components/xiaomi_vac/cloud/mqtt.py
+++ b/custom_components/xiaomi_vac/cloud/mqtt.py
@@ -199,7 +199,9 @@ class MiotMqttClient:
         # Rebuild rather than mutating a live client — avoids racing paho's
         # network thread on username_pw_set + reconnect.
         self._token = new_token
-        fresh = self._build_client(new_token)
+        fresh = await self._hass.async_add_executor_job(
+            self._build_client, new_token
+        )
         fresh.connect_async(self._host, _MQTT_PORT, _MQTT_KEEPALIVE)
         fresh.loop_start()
         self._client = fresh

--- a/custom_components/xiaomi_vac/cloud/oauth.py
+++ b/custom_components/xiaomi_vac/cloud/oauth.py
@@ -19,6 +19,7 @@ from ..const import (
     CONF_OAUTH_EXPIRES_TS,
     CONF_OAUTH_REFRESH_TOKEN,
     CONF_OAUTH_REGION,
+    CONF_OAUTH_REDIRECT_URI,
 )
 
 if TYPE_CHECKING:
@@ -58,14 +59,16 @@ def oauth_state(device_id: str) -> str:
     return hashlib.sha1(f"d={device_id}".encode()).hexdigest()
 
 
-def build_authorize_url(device_id: str) -> str:
+def build_authorize_url(
+    device_id: str, *, redirect_uri: str = OAUTH_REDIRECT_URI
+) -> str:
     """Build the Xiaomi OAuth authorize URL."""
     return (
         f"{OAUTH_AUTHORIZE_URL}?"
         + urlencode(
             {
                 "client_id": OAUTH_APP_ID,
-                "redirect_uri": OAUTH_REDIRECT_URI,
+                "redirect_uri": redirect_uri,
                 "response_type": "code",
                 "device_id": device_id,
                 "state": oauth_state(device_id),
@@ -97,6 +100,7 @@ def exchange_code(
     device_id: str,
     region: str,
     *,
+    redirect_uri: str = OAUTH_REDIRECT_URI,
     session: requests.Session | None = None,
     now: float | None = None,
 ) -> OAuthTokenSet:
@@ -105,7 +109,7 @@ def exchange_code(
         region,
         {
             "client_id": int(OAUTH_APP_ID),
-            "redirect_uri": OAUTH_REDIRECT_URI,
+            "redirect_uri": redirect_uri,
             "code": code,
             "device_id": device_id,
         },
@@ -118,6 +122,7 @@ def refresh_tokens(
     refresh_token: str,
     region: str,
     *,
+    redirect_uri: str = OAUTH_REDIRECT_URI,
     session: requests.Session | None = None,
     now: float | None = None,
 ) -> OAuthTokenSet:
@@ -126,7 +131,7 @@ def refresh_tokens(
         region,
         {
             "client_id": int(OAUTH_APP_ID),
-            "redirect_uri": OAUTH_REDIRECT_URI,
+            "redirect_uri": redirect_uri,
             "refresh_token": refresh_token,
         },
         session=session,
@@ -134,7 +139,11 @@ def refresh_tokens(
     )
 
 
-def oauth_entry_updates(tokens: OAuthTokenSet, device_id: str) -> dict[str, Any]:
+def oauth_entry_updates(
+    tokens: OAuthTokenSet,
+    device_id: str,
+    redirect_uri: str = OAUTH_REDIRECT_URI,
+) -> dict[str, Any]:
     """Return config-entry data updates for OAuth tokens."""
     return {
         CONF_OAUTH_ACCESS_TOKEN: tokens.access_token,
@@ -142,6 +151,7 @@ def oauth_entry_updates(tokens: OAuthTokenSet, device_id: str) -> dict[str, Any]
         CONF_OAUTH_EXPIRES_TS: tokens.expires_ts,
         CONF_OAUTH_REGION: tokens.region,
         CONF_OAUTH_DEVICE_ID: device_id,
+        CONF_OAUTH_REDIRECT_URI: redirect_uri,
     }
 
 
@@ -165,12 +175,14 @@ def refreshed_oauth_entry_updates(
     refresh_token = data.get(CONF_OAUTH_REFRESH_TOKEN)
     region = data.get(CONF_OAUTH_REGION)
     device_id = data.get(CONF_OAUTH_DEVICE_ID)
+    redirect_uri = str(data.get(CONF_OAUTH_REDIRECT_URI) or OAUTH_REDIRECT_URI)
     if not refresh_token or not region or not device_id:
         return None
     tokens = refresh_tokens(
-        str(refresh_token), str(region), session=session, now=now
+        str(refresh_token), str(region), redirect_uri=redirect_uri,
+        session=session, now=now
     )
-    return oauth_entry_updates(tokens, str(device_id))
+    return oauth_entry_updates(tokens, str(device_id), redirect_uri)
 
 
 async def async_refresh_oauth_entry(

--- a/custom_components/xiaomi_vac/config_flow.py
+++ b/custom_components/xiaomi_vac/config_flow.py
@@ -4,8 +4,10 @@ See docs/dev/module-notes.md for design rationale.
 """
 from __future__ import annotations
 
+import asyncio
 import logging
 from collections.abc import Mapping
+from functools import partial
 from typing import Any
 
 import voluptuous as vol
@@ -21,6 +23,7 @@ from homeassistant.helpers import config_validation as cv
 from .captcha_view import IMG_URL, ensure_registered, set_image
 from .cloud.connector import XiaomiCloud
 from .cloud.oauth import (
+    OAUTH_REDIRECT_URI,
     XiaomiOAuthError,
     build_authorize_url,
     exchange_code,
@@ -46,6 +49,7 @@ from .const import (
     DOMAIN,
 )
 from .device import IjaiVacuumDevice
+from .oauth_flow import OAuthCodeLink
 from .spec.registry import is_supported
 
 _LOGGER = logging.getLogger(__name__)
@@ -73,6 +77,49 @@ def _probe(host: str, token: str) -> dict[str, str]:
     return {"model": info.model, "mac": info.mac_address or ""}
 
 
+async def _async_exchange_linked_oauth(
+    hass,
+    link: OAuthCodeLink,
+    data: Mapping[str, Any],
+    device_id: str,
+) -> dict[str, Any]:
+    result = await link.async_wait_code()
+    region = resolve_region_from_code(result.code, data.get(CONF_SERVER))
+    if region is None:
+        raise XiaomiOAuthError("Could not resolve OAuth region")
+    tokens = await hass.async_add_executor_job(
+        partial(
+            exchange_code,
+            result.code,
+            device_id,
+            region,
+            redirect_uri=result.redirect_uri,
+        )
+    )
+    return oauth_entry_updates(tokens, device_id, result.redirect_uri)
+
+
+async def _async_exchange_manual_oauth(
+    hass,
+    code: str,
+    data: Mapping[str, Any],
+    device_id: str,
+) -> dict[str, Any]:
+    region = resolve_region_from_code(code, data.get(CONF_SERVER))
+    if region is None:
+        raise XiaomiOAuthError("Could not resolve OAuth region")
+    tokens = await hass.async_add_executor_job(
+        partial(
+            exchange_code,
+            code,
+            device_id,
+            region,
+            redirect_uri=OAUTH_REDIRECT_URI,
+        )
+    )
+    return oauth_entry_updates(tokens, device_id, OAUTH_REDIRECT_URI)
+
+
 class XiaomiVacuumConfigFlow(ConfigFlow, domain=DOMAIN):
     VERSION = 2
 
@@ -87,6 +134,9 @@ class XiaomiVacuumConfigFlow(ConfigFlow, domain=DOMAIN):
         self._cap_n = 0
         self._data: dict[str, Any] = {}
         self._title = ""
+        self._oauth_link: OAuthCodeLink | None = None
+        self._oauth_task: asyncio.Task[dict[str, Any]] | None = None
+        self._oauth_error: str | None = None
 
     # --- entry: pick login method ---------------------------------------
     async def async_step_user(
@@ -296,29 +346,83 @@ class XiaomiVacuumConfigFlow(ConfigFlow, domain=DOMAIN):
     async def async_step_miot_oauth_auth(
         self, user_input: dict[str, Any] | None = None
     ) -> ConfigFlowResult:
-        """Exchange the Xiaomi OAuth code for MQTT access tokens."""
+        """Link Xiaomi OAuth through a HA webhook callback."""
+        device_id = str(
+            self._data.setdefault(CONF_OAUTH_DEVICE_ID, generate_oauth_device_id())
+        )
+        if self._oauth_task is None:
+            self._oauth_link = OAuthCodeLink(self.hass, device_id)
+            self._oauth_link.register()
+            self._oauth_task = self.hass.async_create_task(
+                _async_exchange_linked_oauth(
+                    self.hass, self._oauth_link, self._data, device_id
+                )
+            )
+
+        if self._oauth_task.done():
+            try:
+                self._data.update(self._oauth_task.result())
+            except XiaomiOAuthError as err:
+                if "region" in str(err):
+                    self._oauth_error = "oauth_region_failed"
+                else:
+                    _LOGGER.exception("Xiaomi OAuth exchange failed")
+                    self._oauth_error = "oauth_failed"
+                self._oauth_task = None
+                self._oauth_link = None
+                return self.async_show_progress_done(
+                    next_step_id="miot_oauth_code"
+                )
+            self._oauth_task = None
+            self._oauth_link = None
+            return self.async_show_progress_done(next_step_id="miot_oauth_finish")
+
+        return self.async_show_progress(
+            step_id="miot_oauth_auth",
+            progress_action="miot_oauth_auth",
+            progress_task=self._oauth_task,
+            description_placeholders={
+                "authorize_url": self._oauth_link.authorize_url
+            },
+        )
+
+    async def async_step_miot_oauth_finish(
+        self, user_input: dict[str, Any] | None = None
+    ) -> ConfigFlowResult:
+        """Finish entry creation after automatic OAuth completes."""
+        return self._create_entry()
+
+    async def async_step_miot_oauth_code(
+        self, user_input: dict[str, Any] | None = None
+    ) -> ConfigFlowResult:
+        """Fallback paste-code flow for browsers that cannot reach HA."""
         errors: dict[str, str] = {}
+        if self._oauth_error:
+            errors["base"] = self._oauth_error
+            self._oauth_error = None
         device_id = str(
             self._data.setdefault(CONF_OAUTH_DEVICE_ID, generate_oauth_device_id())
         )
         if user_input is not None:
             code = user_input["code"].strip()
-            region = resolve_region_from_code(code, self._data.get(CONF_SERVER))
-            if region is None:
-                errors["base"] = "oauth_region_failed"
-            else:
-                try:
-                    tokens = await self.hass.async_add_executor_job(
-                        exchange_code, code, device_id, region
+            try:
+                self._data.update(
+                    await _async_exchange_manual_oauth(
+                        self.hass, code, self._data, device_id
                     )
-                except XiaomiOAuthError:
+                )
+            except XiaomiOAuthError as err:
+                if "region" in str(err):
+                    errors["base"] = "oauth_region_failed"
+                else:
                     _LOGGER.exception("Xiaomi OAuth exchange failed")
                     errors["base"] = "oauth_failed"
-                else:
-                    self._data.update(oauth_entry_updates(tokens, device_id))
-                    return self._create_entry()
+            else:
+                return self._create_entry()
+            if errors.get("base") is None:
+                errors["base"] = "oauth_region_failed"
         return self.async_show_form(
-            step_id="miot_oauth_auth",
+            step_id="miot_oauth_code",
             data_schema=OAUTH_CODE_SCHEMA,
             errors=errors,
             description_placeholders={
@@ -345,6 +449,12 @@ class XiaomiVacuumOptionsFlow(OptionsFlow):
     and re-adding the integration.
     """
 
+    def __init__(self) -> None:
+        self._oauth_device_id: str | None = None
+        self._oauth_link: OAuthCodeLink | None = None
+        self._oauth_task: asyncio.Task[dict[str, Any]] | None = None
+        self._oauth_error: str | None = None
+
     async def async_step_init(
         self, user_input: dict[str, Any] | None = None
     ) -> ConfigFlowResult:
@@ -353,14 +463,72 @@ class XiaomiVacuumOptionsFlow(OptionsFlow):
             return self.async_abort(reason="oauth_local_only")
         return await self.async_step_miot_oauth_auth()
 
-    _oauth_device_id: str | None = None
-
     async def async_step_miot_oauth_auth(
         self, user_input: dict[str, Any] | None = None
     ) -> ConfigFlowResult:
-        errors: dict[str, str] = {}
         data = dict(self.config_entry.data)
-        # Generate once: the auth code is bound to the device_id in the URL.
+        if self._oauth_device_id is None:
+            self._oauth_device_id = str(
+                data.get(CONF_OAUTH_DEVICE_ID) or generate_oauth_device_id()
+            )
+        device_id = self._oauth_device_id
+
+        if self._oauth_task is None:
+            self._oauth_link = OAuthCodeLink(self.hass, device_id)
+            self._oauth_link.register()
+            self._oauth_task = self.hass.async_create_task(
+                _async_exchange_linked_oauth(
+                    self.hass, self._oauth_link, data, device_id
+                )
+            )
+
+        if self._oauth_task.done():
+            try:
+                updates = self._oauth_task.result()
+            except XiaomiOAuthError as err:
+                if "region" in str(err):
+                    self._oauth_error = "oauth_region_failed"
+                else:
+                    _LOGGER.exception("Xiaomi OAuth exchange failed")
+                    self._oauth_error = "oauth_failed"
+                self._oauth_task = None
+                self._oauth_link = None
+                return self.async_show_progress_done(
+                    next_step_id="miot_oauth_code"
+                )
+            data.update(updates)
+            self.hass.config_entries.async_update_entry(
+                self.config_entry, data=data
+            )
+            await self.hass.config_entries.async_reload(
+                self.config_entry.entry_id
+            )
+            self._oauth_task = None
+            self._oauth_link = None
+            return self.async_show_progress_done(next_step_id="miot_oauth_finish")
+
+        return self.async_show_progress(
+            step_id="miot_oauth_auth",
+            progress_action="miot_oauth_auth",
+            progress_task=self._oauth_task,
+            description_placeholders={
+                "authorize_url": self._oauth_link.authorize_url
+            },
+        )
+
+    async def async_step_miot_oauth_finish(
+        self, user_input: dict[str, Any] | None = None
+    ) -> ConfigFlowResult:
+        return self.async_create_entry(title="", data={})
+
+    async def async_step_miot_oauth_code(
+        self, user_input: dict[str, Any] | None = None
+    ) -> ConfigFlowResult:
+        errors: dict[str, str] = {}
+        if self._oauth_error:
+            errors["base"] = self._oauth_error
+            self._oauth_error = None
+        data = dict(self.config_entry.data)
         if self._oauth_device_id is None:
             self._oauth_device_id = str(
                 data.get(CONF_OAUTH_DEVICE_ID) or generate_oauth_device_id()
@@ -368,28 +536,28 @@ class XiaomiVacuumOptionsFlow(OptionsFlow):
         device_id = self._oauth_device_id
         if user_input is not None:
             code = user_input["code"].strip()
-            region = resolve_region_from_code(code, data.get(CONF_SERVER))
-            if region is None:
-                errors["base"] = "oauth_region_failed"
-            else:
-                try:
-                    tokens = await self.hass.async_add_executor_job(
-                        exchange_code, code, device_id, region
+            try:
+                data.update(
+                    await _async_exchange_manual_oauth(
+                        self.hass, code, data, device_id
                     )
-                except XiaomiOAuthError:
+                )
+            except XiaomiOAuthError as err:
+                if "region" in str(err):
+                    errors["base"] = "oauth_region_failed"
+                else:
                     _LOGGER.exception("Xiaomi OAuth exchange failed")
                     errors["base"] = "oauth_failed"
-                else:
-                    data.update(oauth_entry_updates(tokens, device_id))
-                    self.hass.config_entries.async_update_entry(
-                        self.config_entry, data=data
-                    )
-                    await self.hass.config_entries.async_reload(
-                        self.config_entry.entry_id
-                    )
-                    return self.async_create_entry(title="", data={})
+            else:
+                self.hass.config_entries.async_update_entry(
+                    self.config_entry, data=data
+                )
+                await self.hass.config_entries.async_reload(
+                    self.config_entry.entry_id
+                )
+                return self.async_create_entry(title="", data={})
         return self.async_show_form(
-            step_id="miot_oauth_auth",
+            step_id="miot_oauth_code",
             data_schema=OAUTH_CODE_SCHEMA,
             errors=errors,
             description_placeholders={

--- a/custom_components/xiaomi_vac/config_flow.py
+++ b/custom_components/xiaomi_vac/config_flow.py
@@ -273,7 +273,17 @@ class XiaomiVacuumConfigFlow(ConfigFlow, domain=DOMAIN):
             if self.source == SOURCE_REAUTH:
                 return self._finish_reauth()
             return await self.async_step_devices()
-        return self.async_abort(reason="login_failed")
+        # 登录验证失败 = Xiaomi blocked the sign-in pending account verification,
+        # not bad credentials. Point the user at Xiaomi's own sign-in first.
+        reason_text = getattr(self._cloud, "login_error", "")
+        if not isinstance(reason_text, str):
+            reason_text = ""
+        if "登录验证失败" in reason_text:
+            return self.async_abort(reason="login_verification_required")
+        return self.async_abort(
+            reason="login_failed",
+            description_placeholders={"reason": reason_text or "unknown"},
+        )
 
     # --- device discovery + pick ----------------------------------------
     async def async_step_devices(

--- a/custom_components/xiaomi_vac/const.py
+++ b/custom_components/xiaomi_vac/const.py
@@ -21,6 +21,7 @@ CONF_OAUTH_REFRESH_TOKEN = "oauth_refresh_token"
 CONF_OAUTH_EXPIRES_TS = "oauth_expires_ts"
 CONF_OAUTH_REGION = "oauth_region"
 CONF_OAUTH_DEVICE_ID = "oauth_device_id"
+CONF_OAUTH_REDIRECT_URI = "oauth_redirect_uri"
 
 DEFAULT_SCAN_INTERVAL = 10  # seconds, local MIoT polling
 MAP_SCAN_INTERVAL = 30      # seconds, cloud map refresh while cleaning

--- a/custom_components/xiaomi_vac/device.py
+++ b/custom_components/xiaomi_vac/device.py
@@ -172,28 +172,42 @@ class IjaiVacuumDevice:
         cap = self.profile.room_clean
         if cap is None:
             raise ValueError(f"{self.model} has no room-clean capability")
-        # MIoT action input is an ordered list of values (one per in-piid).
-        joined = ",".join(str(r) for r in room_ids)
-        if cap.start is not None:
-            self._action(cap.start, [joined])
+        start = self.room_clean_start_params(room_ids)
+        if start is not None:
+            action, params = start
+            self._action(action, params)
             return
-        if (
-            cap.set_room_clean is not None
+        fallback = self.room_clean_set_params(room_ids)
+        if fallback is not None:
+            action, params = fallback
+            self._action(action, params)
+            return
+        raise ValueError(f"{self.model} has no usable room-clean action")
+
+    def room_clean_start_params(self, room_ids: list[int | str]) -> tuple[object, list] | None:
+        """Return the direct room-clean action and params, when available."""
+        cap = self.profile.room_clean
+        if cap is None or cap.start is None:
+            return None
+        return cap.start, [",".join(str(r) for r in room_ids)]
+
+    def room_clean_set_params(self, room_ids: list[int | str]) -> tuple[object, list] | None:
+        """Return the set-room-clean action and params, when available."""
+        cap = self.profile.room_clean
+        if not (
+            cap is not None
+            and cap.set_room_clean is not None
             and cap.clean_room_ids is not None
             and cap.clean_room_mode is not None
             and cap.clean_room_oper is not None
         ):
-            values = {
-                cap.clean_room_mode.piid: 0,  # global/all rooms mode
-                cap.clean_room_oper.piid: 1,  # start
-                cap.clean_room_ids.piid: joined,
-            }
-            self._action(
-                cap.set_room_clean,
-                [values[piid] for piid in cap.set_room_clean.in_piids],
-            )
-            return
-        raise ValueError(f"{self.model} has no usable room-clean action")
+            return None
+        values = {
+            cap.clean_room_mode.piid: 0,  # global/all rooms mode
+            cap.clean_room_oper.piid: 1,  # start
+            cap.clean_room_ids.piid: ",".join(str(r) for r in room_ids),
+        }
+        return cap.set_room_clean, [values[piid] for piid in cap.set_room_clean.in_piids]
 
     # --- maps ------------------------------------------------------------
     def map_list(self) -> list[dict]:
@@ -230,11 +244,33 @@ class IjaiVacuumDevice:
         return []
 
     def request_map_upload(self, map_id: int) -> dict:
-        """Trigger upload-by-mapid for a non-active map; returns raw out."""
+        """Trigger a fresh upload for a map-list map; returns raw out."""
         cap = self.profile.map
-        if not isinstance(cap, MapCapability) or cap.upload_by_mapid is None:
+        if not isinstance(cap, MapCapability):
             raise ValueError(f"{self.model} has no map-upload capability")
-        return self._action(cap.upload_by_mapid, [int(map_id)])
+        actions = []
+        if cap.get_map_list is not None and cap.upload_by_mapid_ii is not None:
+            actions.append(cap.upload_by_mapid_ii)
+        if cap.upload_by_mapid is not None:
+            actions.append(cap.upload_by_mapid)
+        elif cap.upload_by_mapid_ii is not None:
+            actions.append(cap.upload_by_mapid_ii)
+        if not actions:
+            raise ValueError(f"{self.model} has no map-upload capability")
+        last_error: Exception | None = None
+        for action in actions:
+            try:
+                return self._action(action, [int(map_id)])
+            except Exception as err:  # noqa: BLE001
+                last_error = err
+                if action is not actions[-1]:
+                    _LOGGER.debug(
+                        "map upload action %s/%s failed, trying fallback: %s",
+                        action.siid, action.aiid, err,
+                    )
+                    continue
+                raise
+        raise ValueError(f"{self.model} map-upload failed: {last_error}")
 
     def set_current_map(self, map_id: int) -> None:
         """Switch the vacuum's active map (multi-map devices)."""

--- a/custom_components/xiaomi_vac/manifest.json
+++ b/custom_components/xiaomi_vac/manifest.json
@@ -20,5 +20,5 @@
     "Pillow==12.2.0",
     "paho-mqtt==2.1.0"
   ],
-  "version": "1.2.0"
+  "version": "1.2.1"
 }

--- a/custom_components/xiaomi_vac/map.py
+++ b/custom_components/xiaomi_vac/map.py
@@ -189,23 +189,32 @@ class MapFetcher:
             raise SessionExpired()
         raw = self._cloud.download(url)
         if not raw:
-            _LOGGER.warning("Map download failed (slot %s)", slot)
+            # Not per-slot actionable; the coordinator raises UpdateFailed when
+            # every fallback (both slots + cache) comes up empty.
+            _LOGGER.debug("Map download failed (slot %s)", slot)
             return None
 
         try:
             unpacked = self._unpack(raw)
-            md = self._parser.parse(unpacked)
-            vector = map_vector.vector_map(md, unpacked, ijai_grid=self._ijai_grid)
         except Exception as ex:  # noqa: BLE001
-            # A corrupt/incomplete map, OR (routinely, per the map-reliability
-            # plan) an undecryptable "Key B" blob at this slot. Neither should
-            # crash the coordinator — the caller falls back to the other slot
-            # or the cache.
+            # Decrypt/decompress failed: a corrupt blob OR (routinely, per the
+            # map-reliability plan) an undecryptable "Key B" blob at this slot.
+            # Never crash the coordinator — it falls back to the other slot or
+            # the cache. A stale dreame enckey also lands here: drop it so the
+            # next fetch re-polls siid=6/piid=3.
             if self._brand == "dreame" and self._enckey is not None:
                 _LOGGER.debug("dreame decrypt failed; will re-poll enckey next fetch: %s", ex)
                 self._enckey = None
                 self._enckey_polled = False
-            _LOGGER.debug("Could not decode map at slot %s: %s", slot, ex)
+            _LOGGER.debug("Could not decrypt map at slot %s: %s", slot, ex)
+            return None
+        try:
+            md = self._parser.parse(unpacked)
+            vector = map_vector.vector_map(md, unpacked, ijai_grid=self._ijai_grid)
+        except Exception as ex:  # noqa: BLE001
+            # Decrypted fine but the parser rejected the frame (corrupt or
+            # unexpected layout). The key material is good — keep the enckey.
+            _LOGGER.debug("Parser rejected map frame at slot %s: %s", slot, ex)
             return None
         if md.image is None or md.image.is_empty:
             _LOGGER.debug("Parsed map at slot %s is empty", slot)

--- a/custom_components/xiaomi_vac/map_coordinator.py
+++ b/custom_components/xiaomi_vac/map_coordinator.py
@@ -46,6 +46,7 @@ _PIID_CUR_MAP = 2      # properties_changed/10/2 = curMapId
 
 # Burst window: collapse multiple upload events within this window into one fetch
 _DEBOUNCE_SECONDS = 2.0
+_MAP_UPLOAD_THROTTLE_SECONDS = 30.0
 _MAP_REFRESH_WAIT_SECONDS = 120.0
 _MAP_REFRESH_POLL_SECONDS = 3.0
 _REFRESH_READY_ACTIVITIES = {"docked", "idle"}
@@ -105,9 +106,12 @@ class XiaomiMapCoordinator(DataUpdateCoordinator[MapResult]):
         # read for this cycle failed (None = not yet signaled by MQTT).
         self._mqtt_active_id: int | None = None
         self._mqtt_debounce_task: asyncio.Task | None = None
+        self._mqtt_refresh_needs_upload = False
         self._mqtt_upload_waiters: set[asyncio.Future[None]] = set()
+        self._last_upload_request_at: dict[int, float] = {}
         self._last_live_at: float | None = None
         self._refresh_map_lock = asyncio.Lock()
+        self._pending_entry_updates: dict[str, str] = {}
 
     @property
     def device(self) -> IjaiVacuumDevice:
@@ -143,11 +147,11 @@ class XiaomiMapCoordinator(DataUpdateCoordinator[MapResult]):
             except (TypeError, ValueError):
                 pass
             _LOGGER.debug("MQTT curMapId=%s — scheduling map refresh", self._mqtt_active_id)
-            self._schedule_mqtt_refresh()
+            self._schedule_mqtt_refresh(request_upload=True)
         elif msg.kind == "event" and msg.siid == _SIID_MAP and msg.eiid == _EIID_MAP_UPLOAD:
             _LOGGER.debug("MQTT map upload event — scheduling map refresh")
             self._notify_mqtt_upload_waiters()
-            self._schedule_mqtt_refresh()
+            self._schedule_mqtt_refresh(request_upload=True)
 
     def _new_mqtt_upload_waiter(self) -> asyncio.Future[None]:
         waiter: asyncio.Future[None] = self.hass.loop.create_future()
@@ -227,8 +231,9 @@ class XiaomiMapCoordinator(DataUpdateCoordinator[MapResult]):
                     with contextlib.suppress(Exception):
                         await self._control.async_request_refresh()
 
-    def _schedule_mqtt_refresh(self) -> None:
+    def _schedule_mqtt_refresh(self, *, request_upload: bool = False) -> None:
         """Cancel any pending debounce task and start a fresh one."""
+        self._mqtt_refresh_needs_upload = self._mqtt_refresh_needs_upload or request_upload
         if self._mqtt_debounce_task is not None:
             self._mqtt_debounce_task.cancel()
         self._mqtt_debounce_task = self.hass.async_create_task(
@@ -241,7 +246,45 @@ class XiaomiMapCoordinator(DataUpdateCoordinator[MapResult]):
         except asyncio.CancelledError:
             return
         self._mqtt_debounce_task = None
+        request_upload = self._mqtt_refresh_needs_upload
+        self._mqtt_refresh_needs_upload = False
+        if request_upload:
+            await self.async_request_map_upload(self._mqtt_active_id)
         await self.async_refresh()
+
+    def _known_active_map_id(self) -> int | None:
+        if self._mqtt_active_id is not None:
+            return self._mqtt_active_id
+        for meta in self._map_list_meta:
+            if meta.get("cur") and meta.get("id") is not None:
+                try:
+                    return int(meta["id"])
+                except (TypeError, ValueError):
+                    return None
+        if self.data is not None and self.data.map_id is not None:
+            return self.data.map_id
+        return None
+
+    async def async_request_map_upload(self, map_id: int | None = None) -> bool:
+        """Ask the vacuum to upload a fresh cloud blob for a map-list map."""
+        target = self._known_active_map_id() if map_id is None else map_id
+        if target is None:
+            return False
+        target = int(target)
+        now = time.monotonic()
+        last = self._last_upload_request_at.get(target, 0.0)
+        if now - last < _MAP_UPLOAD_THROTTLE_SECONDS:
+            _LOGGER.debug("Skipping throttled map upload request for map_id=%s", target)
+            return False
+        self._last_upload_request_at[target] = now
+        try:
+            await self.hass.async_add_executor_job(
+                self._device.request_map_upload, target
+            )
+        except Exception as err:  # noqa: BLE001
+            _LOGGER.debug("Map upload request failed for map_id=%s: %s", target, err)
+            return False
+        return True
 
     def _build(self) -> MapFetcher:
         """Blocking: restore the saved cloud session and construct a fetcher.
@@ -250,6 +293,7 @@ class XiaomiMapCoordinator(DataUpdateCoordinator[MapResult]):
         the map AES key); the values stashed at setup time can be empty/stale.
         """
         d = self.entry.data
+        self._pending_entry_updates = {}
         # No password: the saved session is restored and renewed via passToken.
         cloud = XiaomiCloud(d[CONF_USERNAME])
         cloud.restore_session(d[CONF_USER_ID], d[CONF_SSECURITY], d[CONF_SERVICE_TOKEN],
@@ -267,19 +311,29 @@ class XiaomiMapCoordinator(DataUpdateCoordinator[MapResult]):
         if required:
             live_sn = self._device.get_wifi_sn(d[CONF_USER_ID])
             live_mac = self._device.get_mac()
-            wifi_sn = live_sn or d.get(CONF_WIFI_SN) or ""
-            mac = live_mac or d.get(CONF_MAC) or ""
+            stored_sn = d.get(CONF_WIFI_SN) or ""
+            stored_mac = d.get(CONF_MAC) or ""
+            wifi_sn = live_sn or stored_sn
+            mac = live_mac or stored_mac
+            if live_sn and live_sn != stored_sn:
+                self._pending_entry_updates[CONF_WIFI_SN] = live_sn
+            if live_mac and live_mac != stored_mac:
+                self._pending_entry_updates[CONF_MAC] = live_mac
 
         _LOGGER.debug(
             "Map key inputs: brand=%s wifi_sn=%r mac=%s user_id=%s device_id=%s model=%s",
             brand, wifi_sn, mac, d[CONF_USER_ID], d[CONF_DEVICE_ID], d[CONF_MODEL],
         )
         if "wifi_sn" in required and not wifi_sn:
-            raise UpdateFailed("Could not read wifi_sn from the vacuum (needed to decrypt map)")
+            raise UpdateFailed(
+                "Missing map key input wifi_sn: could not read it live or from storage"
+            )
         if "device_mac" in required and not mac:
             # An empty mac silently produces the wrong AES key (decrypt fails
             # with "Padding is incorrect"), so refuse to build with one.
-            raise UpdateFailed("Could not read mac from the vacuum (needed to decrypt map)")
+            raise UpdateFailed(
+                "Missing map key input mac: could not read it live or from storage"
+            )
 
         return MapFetcher(
             cloud,
@@ -291,6 +345,15 @@ class XiaomiMapCoordinator(DataUpdateCoordinator[MapResult]):
             wifi_sn=wifi_sn,
             parser_brand=brand,
         )
+
+    def _persist_pending_entry_updates(self) -> None:
+        if not self._pending_entry_updates:
+            return
+        self.hass.config_entries.async_update_entry(
+            self.entry,
+            data={**self.entry.data, **self._pending_entry_updates},
+        )
+        self._pending_entry_updates = {}
 
     async def _ensure_cache(self) -> MapCache:
         if self._cache is None:
@@ -373,6 +436,7 @@ class XiaomiMapCoordinator(DataUpdateCoordinator[MapResult]):
         try:
             if self._fetcher is None:
                 self._fetcher = await self.hass.async_add_executor_job(self._build)
+                self._persist_pending_entry_updates()
             cache = await self._ensure_cache()
 
             # The map list (distinct physical maps) drives multi-map; best-effort
@@ -394,7 +458,7 @@ class XiaomiMapCoordinator(DataUpdateCoordinator[MapResult]):
                 # If renewal fails, the passToken is dead too: ask the user to
                 # re-auth (raises a reauth flow) rather than dead-end.
                 if not await self._refresh_and_persist():
-                    raise ConfigEntryAuthFailed("Cloud session expired") from None
+                    raise ConfigEntryAuthFailed("Xiaomi cloud map session expired") from None
                 slot_results = await self.hass.async_add_executor_job(self._fetch_slots)
 
             decoded = [r for r in slot_results if r is not None]
@@ -459,7 +523,7 @@ class XiaomiMapCoordinator(DataUpdateCoordinator[MapResult]):
         except (UpdateFailed, ConfigEntryAuthFailed):
             raise
         except SessionExpired:
-            raise ConfigEntryAuthFailed("Cloud session expired") from None
+            raise ConfigEntryAuthFailed("Xiaomi cloud map session expired") from None
         except Exception as err:  # noqa: BLE001
             self._fetcher = None
             raise UpdateFailed(f"Map update error: {err}") from err

--- a/custom_components/xiaomi_vac/map_coordinator.py
+++ b/custom_components/xiaomi_vac/map_coordinator.py
@@ -272,8 +272,10 @@ class XiaomiMapCoordinator(DataUpdateCoordinator[MapResult]):
             return False
         target = int(target)
         now = time.monotonic()
-        last = self._last_upload_request_at.get(target, 0.0)
-        if now - last < _MAP_UPLOAD_THROTTLE_SECONDS:
+        # None sentinel, not 0.0: monotonic() is ~uptime, so a 0.0 default
+        # falsely throttles the first request within 30s of boot.
+        last = self._last_upload_request_at.get(target)
+        if last is not None and now - last < _MAP_UPLOAD_THROTTLE_SECONDS:
             _LOGGER.debug("Skipping throttled map upload request for map_id=%s", target)
             return False
         self._last_upload_request_at[target] = now

--- a/custom_components/xiaomi_vac/map_parsers.py
+++ b/custom_components/xiaomi_vac/map_parsers.py
@@ -21,7 +21,8 @@ def dreame_extract_enckey(prop_value: str) -> str | None:
     if not prop_value or "," not in prop_value:
         return None
     parts = prop_value.split(",")
-    return parts[1] if len(parts) > 1 else None
+    # `or None`: an empty key ("path,") means no usable enckey.
+    return (parts[1] or None) if len(parts) > 1 else None
 
 
 def dreame_decrypt_cloud_blob(raw: bytes, enckey: str) -> bytes:

--- a/custom_components/xiaomi_vac/oauth_flow.py
+++ b/custom_components/xiaomi_vac/oauth_flow.py
@@ -1,0 +1,125 @@
+"""OAuth webhook link helpers for Xiaomi account linking."""
+from __future__ import annotations
+
+from dataclasses import dataclass
+from html import escape
+import asyncio
+import uuid
+
+from aiohttp import web
+from aiohttp.hdrs import METH_GET
+from homeassistant.components.webhook import (
+    async_generate_path as webhook_async_generate_path,
+    async_register as webhook_async_register,
+    async_unregister as webhook_async_unregister,
+)
+from homeassistant.core import HomeAssistant
+
+from .cloud.oauth import OAUTH_REDIRECT_URI, build_authorize_url, oauth_state
+from .const import DOMAIN
+
+_OAUTH_LINKS = "oauth_links"
+
+
+@dataclass(frozen=True)
+class OAuthCodeResult:
+    """OAuth callback code plus the redirect URI used to mint it."""
+
+    code: str
+    redirect_uri: str
+
+
+class OAuthCodeLink:
+    """One-shot OAuth callback link backed by a Home Assistant webhook."""
+
+    def __init__(self, hass: HomeAssistant, device_id: str) -> None:
+        self.hass = hass
+        self.device_id = device_id
+        self.webhook_id = f"{DOMAIN}_oauth_{uuid.uuid4().hex}"
+        self.redirect_uri = f"{OAUTH_REDIRECT_URI}{webhook_async_generate_path(self.webhook_id)}"
+        self.authorize_url = build_authorize_url(
+            device_id, redirect_uri=self.redirect_uri
+        )
+        self.state = oauth_state(device_id)
+        self.future: asyncio.Future[OAuthCodeResult] = hass.loop.create_future()
+        self._registered = False
+
+    def register(self) -> None:
+        """Register the callback webhook for this OAuth attempt."""
+        if self._registered:
+            return
+        self.hass.data.setdefault(DOMAIN, {}).setdefault(_OAUTH_LINKS, {})[
+            self.webhook_id
+        ] = self
+        webhook_async_register(
+            self.hass,
+            domain=DOMAIN,
+            name="Xiaomi Vacuum OAuth callback",
+            webhook_id=self.webhook_id,
+            handler=_handle_oauth_webhook,
+            allowed_methods=(METH_GET,),
+        )
+        self._registered = True
+
+    def unregister(self) -> None:
+        """Remove the callback webhook."""
+        if not self._registered:
+            return
+        self.hass.data.get(DOMAIN, {}).get(_OAUTH_LINKS, {}).pop(
+            self.webhook_id, None
+        )
+        webhook_async_unregister(self.hass, webhook_id=self.webhook_id)
+        self._registered = False
+
+    async def async_wait_code(self) -> OAuthCodeResult:
+        """Wait until Xiaomi redirects back with an auth code."""
+        try:
+            return await self.future
+        finally:
+            self.unregister()
+
+
+def _oauth_response(title: str, content: str, *, success: bool) -> web.Response:
+    colour = "#1f8f4d" if success else "#b42318"
+    body = f"""<!doctype html>
+<html lang="en">
+<head><meta charset="utf-8"><title>{escape(title)}</title></head>
+<body style="font-family: system-ui, sans-serif; margin: 3rem; max-width: 40rem;">
+<h1 style="color: {colour};">{escape(title)}</h1>
+<p>{escape(content)}</p>
+<button onclick="window.close()">Close</button>
+</body>
+</html>"""
+    return web.Response(body=body, content_type="text/html")
+
+
+async def _handle_oauth_webhook(
+    hass: HomeAssistant, webhook_id: str, request: web.Request
+) -> web.Response:
+    """Receive Xiaomi's OAuth redirect and wake the waiting flow."""
+    link = hass.data.get(DOMAIN, {}).get(_OAUTH_LINKS, {}).get(webhook_id)
+    if not isinstance(link, OAuthCodeLink):
+        return _oauth_response(
+            "Authentication failed",
+            "This OAuth link is no longer active. Return to Home Assistant and try again.",
+            success=False,
+        )
+
+    code = request.query.get("code")
+    state = request.query.get("state")
+    if not code or state != link.state:
+        return _oauth_response(
+            "Authentication failed",
+            "The Xiaomi OAuth response was not valid. Return to Home Assistant and try again.",
+            success=False,
+        )
+
+    if not link.future.done():
+        link.future.set_result(
+            OAuthCodeResult(code=code, redirect_uri=link.redirect_uri)
+        )
+    return _oauth_response(
+        "Authentication complete",
+        "You can close this page and return to Home Assistant.",
+        success=True,
+    )

--- a/custom_components/xiaomi_vac/select.py
+++ b/custom_components/xiaomi_vac/select.py
@@ -125,4 +125,5 @@ class XiaomiActiveMapSelect(CoordinatorEntity[XiaomiMapCoordinator], SelectEntit
         await self.hass.async_add_executor_job(
             self.coordinator.device.set_current_map, int(target["id"])
         )
+        await self.coordinator.async_request_map_upload(int(target["id"]))
         await self.coordinator.async_request_refresh()

--- a/custom_components/xiaomi_vac/spec/profiles/dreame.py
+++ b/custom_components/xiaomi_vac/spec/profiles/dreame.py
@@ -449,6 +449,94 @@ DREAME_P2036 = ModelProfile(
 )
 
 
+DREAME_P2041_MAP = DreameMapCapability(
+    service=6,
+    map_data=Prop(6, 1),  # map-data — "Map Data"
+    frame_info=Prop(6, 2),  # frame-info — "Frame Information"
+    object_name=Prop(6, 3),  # object-name — "Intermediate Map Data File Name on FDS"
+    map_extend_data=Prop(6, 4),  # map-extend-data — "Map Editing Parameters"
+    robot_time=Prop(6, 5),  # robot-time — "Host Current Timestamp"
+    result_code=Prop(6, 6),  # result-code — "Map Editing Response Code"
+    map_req=Action(6, 1, in_piid=2, out_piids=(1, 3, 5)),  # map-req — "Request Map Data"
+    update_map=Action(6, 2, in_piid=4, out_piids=(6,)),  # update-map — "Update Map Information"
+)
+
+
+DREAME_P2041_SCHEDULE = DreameScheduleCapability(
+    service=8,
+    time_zone=Prop(8, 1),  # time-zone — "Host Timezone Retrieval"
+    timer_clean=Prop(8, 2),  # timer-clean — "Scheduled Reservation Cleaning"
+    timer_id=Prop(8, 3),  # timer-id — "Reservation ID, For Easy Extension, Use String, Comma Separate Each ID (e.g.: "3,15", "1,9,45"), Currently Each Command Uses One ID (e.g.: "2", "60")"
+    delete_timer=Action(8, 1, in_piid=3),  # delete-timer — "Delete Scheduled Reservation"
+)
+
+
+DREAME_P2041_SETTINGS = DreameSettingsCapability(
+    service=4,
+    cleaning_mode=Prop(4, 4),  # cleaning-mode — "Cleaning Mode"
+    mop_mode=Prop(4, 5),  # mop-mode — "Water Level Settings in Mopping Mode"
+    waterbox_status=Prop(4, 6),  # waterbox-status — "Water Tank Status"
+    task_status=Prop(4, 7),  # task-status — "Host Task Status"
+    break_point_restart=Prop(4, 11),  # break-point-restart — "Resume Cleaning Switch"
+    carpet_press=Prop(4, 12),  # carpet-press — "Carpet Boost Switch"
+)
+
+
+DREAME_P2041_CONSUMABLES = DreameConsumablesCapability(
+    main_brush_life=Prop(9, 2),  # brush-life-level — "Cleaning Brush Remaining Life"
+    main_brush_left_time=Prop(9, 1),  # brush-left-time — "Cleaning Brush Remaining Time"
+    reset_main_brush=Action(9, 1),  # reset-brush-life — "Reset Cleaning Brush"
+    side_brush_life=Prop(10, 2),  # brush-life-level — "Cleaning Brush Remaining Life"
+    side_brush_left_time=Prop(10, 1),  # brush-left-time — "Cleaning Brush Remaining Time"
+    reset_side_brush=Action(10, 1),  # reset-brush-life — "Reset Cleaning Brush"
+    filter_life=Prop(11, 1),  # filter-life-level — "Filter Remaining Life"
+    filter_left_time=Prop(11, 2),  # filter-left-time — "Filter Remaining Time"
+    reset_filter=Action(11, 1),  # reset-filter-life — "Reset Filter"
+)
+
+
+DREAME_P2041_CLEAN_HISTORY = DreameCleanHistoryCapability(
+    service=12,
+    first_clean_time=Prop(12, 1),  # first-clean-time — "First Cleaning Start Time"
+    total_clean_time=Prop(12, 2),  # total-clean-time — "Total Cleaning Time"
+    total_clean_times=Prop(12, 3),  # total-clean-times — "Total Cleaning Count"
+    total_clean_area=Prop(12, 4),  # total-clean-area — "Total Cleaning Area"
+)
+
+
+DREAME_P2041_DND = DreameDndCapability(
+    service=5,
+    enable=Prop(5, 1),  # enable — "Enable"
+    start_time=Prop(5, 2),  # start-time — "Do Not Disturb Start Time"
+    end_time=Prop(5, 3),  # end-time — "Do Not Disturb End Time"
+)
+
+
+DREAME_P2041_VOICE = DreameAudioCapability(
+    service=7,
+    voice_packet_id=Prop(7, 2),  # voice-packet-id — "Voice Pack ID"
+    voice_change_state=Prop(7, 3),  # voice-change-state — "Voice Pack Switching Status"
+    set_voice=Prop(7, 4),  # set-voice — "Set Personalized Voice"
+    locate=Action(7, 1),  # position — "Locate My Robot"
+    play_sound=Action(7, 2),  # play-sound — "Voice Preview"
+)
+
+
+DREAME_P2041 = ModelProfile(
+    profile_id="dreame.p2041",
+    brand="dreame",
+    core=DREAME_P2009_CORE,
+    map=DREAME_P2041_MAP,
+    schedule=DREAME_P2041_SCHEDULE,
+    settings=DREAME_P2041_SETTINGS,
+    consumables=DREAME_P2041_CONSUMABLES,
+    clean_history=DREAME_P2041_CLEAN_HISTORY,
+    dnd=DREAME_P2041_DND,
+    voice=DREAME_P2041_VOICE,
+    notes=("urn:miot-spec-v2:device:vacuum:0000A006:dreame-p2041:2",),
+)
+
+
 DREAME_P2114A_CORE = CoreCapability(
     status=Prop(2, 1),  # status — "Working Status"
     fault=Prop(2, 2),  # fault — "Fault"

--- a/custom_components/xiaomi_vac/spec/profiles/dreame.py
+++ b/custom_components/xiaomi_vac/spec/profiles/dreame.py
@@ -132,6 +132,7 @@ DREAME_P2008 = ModelProfile(
     clean_history=DREAME_P2008_CLEAN_HISTORY,
     dnd=DREAME_P2008_DND,
     voice=DREAME_P2008_VOICE,
+    notes=("urn:miot-spec-v2:device:vacuum:0000A006:dreame-p2008:2",),
 )
 
 
@@ -248,6 +249,7 @@ DREAME_P2009 = ModelProfile(
     clean_history=DREAME_P2009_CLEAN_HISTORY,
     dnd=DREAME_P2009_DND,
     voice=DREAME_P2009_VOICE,
+    notes=("urn:miot-spec-v2:device:vacuum:0000A006:dreame-p2009:2",),
 )
 
 
@@ -348,6 +350,7 @@ DREAME_P2027 = ModelProfile(
     clean_history=DREAME_P2027_CLEAN_HISTORY,
     dnd=DREAME_P2027_DND,
     voice=DREAME_P2027_VOICE,
+    notes=("urn:miot-spec-v2:device:vacuum:0000A006:dreame-p2027:3",),
 )
 
 
@@ -442,6 +445,7 @@ DREAME_P2036 = ModelProfile(
     clean_history=DREAME_P2036_CLEAN_HISTORY,
     dnd=DREAME_P2036_DND,
     voice=DREAME_P2036_VOICE,
+    notes=("urn:miot-spec-v2:device:vacuum:0000A006:dreame-p2036:2",),
 )
 
 
@@ -561,6 +565,7 @@ DREAME_P2114A = ModelProfile(
     clean_history=DREAME_P2114A_CLEAN_HISTORY,
     dnd=DREAME_P2114A_DND,
     voice=DREAME_P2114A_VOICE,
+    notes=("urn:miot-spec-v2:device:vacuum:0000A006:dreame-p2114a:2",),
 )
 
 
@@ -660,6 +665,7 @@ DREAME_P2114O = ModelProfile(
     clean_history=DREAME_P2114O_CLEAN_HISTORY,
     dnd=DREAME_P2114O_DND,
     voice=DREAME_P2114O_VOICE,
+    notes=("urn:miot-spec-v2:device:vacuum:0000A006:dreame-p2114o:2",),
 )
 
 
@@ -776,6 +782,7 @@ DREAME_P2149O = ModelProfile(
     clean_history=DREAME_P2149O_CLEAN_HISTORY,
     dnd=DREAME_P2149O_DND,
     voice=DREAME_P2149O_VOICE,
+    notes=("urn:miot-spec-v2:device:vacuum:0000A006:dreame-p2149o:2",),
 )
 
 
@@ -892,6 +899,7 @@ DREAME_P2150A = ModelProfile(
     clean_history=DREAME_P2150A_CLEAN_HISTORY,
     dnd=DREAME_P2150A_DND,
     voice=DREAME_P2150A_VOICE,
+    notes=("urn:miot-spec-v2:device:vacuum:0000A006:dreame-p2150a:2",),
 )
 
 
@@ -988,6 +996,7 @@ DREAME_R2205 = ModelProfile(
     clean_history=DREAME_R2205_CLEAN_HISTORY,
     dnd=DREAME_R2205_DND,
     voice=DREAME_R2205_VOICE,
+    notes=("urn:miot-spec-v2:device:vacuum:0000A006:dreame-r2205:2",),
 )
 
 
@@ -1083,6 +1092,7 @@ DREAME_R2209 = ModelProfile(
     clean_history=DREAME_R2209_CLEAN_HISTORY,
     dnd=DREAME_R2209_DND,
     voice=DREAME_R2209_VOICE,
+    notes=("urn:miot-spec-v2:device:vacuum:0000A006:dreame-r2209:2",),
 )
 
 
@@ -1183,6 +1193,7 @@ DREAME_R2210 = ModelProfile(
     clean_history=DREAME_R2210_CLEAN_HISTORY,
     dnd=DREAME_R2210_DND,
     voice=DREAME_R2210_VOICE,
+    notes=("urn:miot-spec-v2:device:vacuum:0000A006:dreame-r2210:1",),
 )
 
 
@@ -1282,6 +1293,7 @@ DREAME_R2211O = ModelProfile(
     clean_history=DREAME_R2211O_CLEAN_HISTORY,
     dnd=DREAME_R2211O_DND,
     voice=DREAME_R2211O_VOICE,
+    notes=("urn:miot-spec-v2:device:vacuum:0000A006:dreame-r2211o:2",),
 )
 
 
@@ -1402,6 +1414,7 @@ DREAME_R2215 = ModelProfile(
     clean_history=DREAME_R2215_CLEAN_HISTORY,
     dnd=DREAME_R2215_DND,
     voice=DREAME_R2215_VOICE,
+    notes=("urn:miot-spec-v2:device:vacuum:0000A006:dreame-r2215:2",),
 )
 
 
@@ -1499,6 +1512,7 @@ DREAME_R2216O = ModelProfile(
     clean_history=DREAME_R2216O_CLEAN_HISTORY,
     dnd=DREAME_R2216O_DND,
     voice=DREAME_R2216O_VOICE,
+    notes=("urn:miot-spec-v2:device:vacuum:0000A006:dreame-r2216o:1",),
 )
 
 
@@ -1601,6 +1615,7 @@ DREAME_R2228 = ModelProfile(
     clean_history=DREAME_R2228_CLEAN_HISTORY,
     dnd=DREAME_R2228_DND,
     voice=DREAME_R2228_VOICE,
+    notes=("urn:miot-spec-v2:device:vacuum:0000A006:dreame-r2228:2",),
 )
 
 
@@ -1637,6 +1652,7 @@ DREAME_R2235A = ModelProfile(
     core=DREAME_R2235A_CORE,
     room_clean=DREAME_R2235A_ROOM_CLEAN,
     consumables=DREAME_R2235A_CONSUMABLES,
+    notes=("urn:miot-spec-v2:device:vacuum:0000A006:dreame-r2235a:1",),
 )
 
 
@@ -1734,6 +1750,7 @@ DREAME_R2254 = ModelProfile(
     clean_history=DREAME_R2254_CLEAN_HISTORY,
     dnd=DREAME_R2254_DND,
     voice=DREAME_R2254_VOICE,
+    notes=("urn:miot-spec-v2:device:vacuum:0000A006:dreame-r2254:3",),
 )
 
 
@@ -1770,4 +1787,5 @@ DREAME_R2257O = ModelProfile(
     core=DREAME_R2257O_CORE,
     room_clean=DREAME_R2257O_ROOM_CLEAN,
     consumables=DREAME_R2257O_CONSUMABLES,
+    notes=("urn:miot-spec-v2:device:vacuum:0000A006:dreame-r2257o:1",),
 )

--- a/custom_components/xiaomi_vac/spec/profiles/ijai.py
+++ b/custom_components/xiaomi_vac/spec/profiles/ijai.py
@@ -123,6 +123,7 @@ IJAI_CORE_V16 = CoreCapability(
 IJAI_V1 = ModelProfile(
     profile_id='ijai.v1',
     brand='ijai',
+    notes=("urn:miot-spec-v2:device:vacuum:0000A006:ijai-v1:2",),
     core=IJAI_CORE_LEGACY,
     map=MapCapability(
         service=10,
@@ -243,6 +244,7 @@ IJAI_V1 = ModelProfile(
 IJAI_V2 = ModelProfile(
     profile_id='ijai.v2',
     brand='ijai',
+    notes=("urn:miot-spec-v2:device:vacuum:0000A006:ijai-v2:2",),
     core=IJAI_CORE_LEGACY,
     map=MapCapability(
         service=10,
@@ -358,6 +360,7 @@ IJAI_V2 = ModelProfile(
 IJAI_V3 = ModelProfile(
     profile_id='ijai.v3',
     brand='ijai',
+    notes=("urn:miot-spec-v2:device:vacuum:0000A006:ijai-v3:2",),
     core=IJAI_CORE_LEGACY,
     map=MapCapability(
         service=10,
@@ -483,6 +486,7 @@ IJAI_V3 = ModelProfile(
 IJAI_V10 = ModelProfile(
     profile_id='ijai.v10',
     brand='ijai',
+    notes=("urn:miot-spec-v2:device:vacuum:0000A006:ijai-v10:1",),
     core=IJAI_CORE_V10,
     map=MapCapability(
         service=10,
@@ -596,6 +600,7 @@ IJAI_V10 = ModelProfile(
 IJAI_V13 = ModelProfile(
     profile_id='ijai.v13',
     brand='ijai',
+    notes=("urn:miot-spec-v2:device:vacuum:0000A006:ijai-v13:2",),
     core=IJAI_CORE_STD,
     map=MapCapability(
         service=10,
@@ -717,6 +722,7 @@ IJAI_V13 = ModelProfile(
 IJAI_V14 = ModelProfile(
     profile_id='ijai.v14',
     brand='ijai',
+    notes=("urn:miot-spec-v2:device:vacuum:0000A006:ijai-v14:2",),
     core=IJAI_CORE_STD,
     map=MapCapability(
         service=10,
@@ -839,6 +845,7 @@ IJAI_V14 = ModelProfile(
 IJAI_V17 = ModelProfile(
     profile_id='ijai.v17',
     brand='ijai',
+    notes=("urn:miot-spec-v2:device:vacuum:0000A006:ijai-v17:2",),
     core=IJAI_CORE_STD,
     map=MapCapability(
         service=10,
@@ -970,4 +977,9 @@ IJAI_V17 = ModelProfile(
 
 # ijai.vacuum.v16 — identical RICH layout to v10, but a distinct core (STD-style
 # fan/water labels). Split out so v16 doesn't inherit v10's wrong labels.
-IJAI_V16 = replace(IJAI_V10, profile_id='ijai.v16', core=IJAI_CORE_V16)
+IJAI_V16 = replace(
+    IJAI_V10,
+    profile_id='ijai.v16',
+    core=IJAI_CORE_V16,
+    notes=("urn:miot-spec-v2:device:vacuum:0000A006:ijai-v16:1",),
+)

--- a/custom_components/xiaomi_vac/spec/profiles/roidmi.py
+++ b/custom_components/xiaomi_vac/spec/profiles/roidmi.py
@@ -25,6 +25,7 @@ from ..types import (
 ROIDMI_R1B = ModelProfile(
     profile_id='roidmi.r1b',
     brand='roidmi',
+    notes=("urn:miot-spec-v2:device:vacuum:0000A006:roidmi-r1b:2",),
     room_clean=RoomCleanCapability(
         room_ids=Prop(2, 9),
         start=Action(2, 3, in_piid=9),
@@ -35,6 +36,7 @@ ROIDMI_R1B = ModelProfile(
 ROIDMI_SDJ60 = ModelProfile(
     profile_id='roidmi.sdj60',
     brand='roidmi',
+    notes=("urn:miot-spec-v2:device:vacuum:0000A006:roidmi-sdj60:2",),
     room_clean=RoomCleanCapability(
         room_ids=Prop(2, 9),
         start=Action(2, 6, in_piid=9),
@@ -45,6 +47,7 @@ ROIDMI_SDJ60 = ModelProfile(
 ROIDMI_V62 = ModelProfile(
     profile_id='roidmi.v62',
     brand='roidmi',
+    notes=("urn:miot-spec-v2:device:vacuum:0000A006:roidmi-v62:1",),
     map=MapCapability(
         service=10,
         map_num=Prop(10, 3),

--- a/custom_components/xiaomi_vac/spec/profiles/viomi.py
+++ b/custom_components/xiaomi_vac/spec/profiles/viomi.py
@@ -151,6 +151,7 @@ VIOMI_V12 = ModelProfile(
     clean_history=VIOMI_V12_CLEAN_HISTORY,
     dnd=VIOMI_V12_DND,
     voice=VIOMI_V12_VOICE,
+    notes=("urn:miot-spec-v2:device:vacuum:0000A006:viomi-v12:1",),
 )
 
 
@@ -283,6 +284,7 @@ VIOMI_V13 = ModelProfile(
     clean_history=VIOMI_V13_CLEAN_HISTORY,
     dnd=VIOMI_V13_DND,
     voice=VIOMI_V13_VOICE,
+    notes=("urn:miot-spec-v2:device:vacuum:0000A006:viomi-v13:2",),
 )
 
 
@@ -415,6 +417,7 @@ VIOMI_V15 = ModelProfile(
     clean_history=VIOMI_V15_CLEAN_HISTORY,
     dnd=VIOMI_V15_DND,
     voice=VIOMI_V15_VOICE,
+    notes=("urn:miot-spec-v2:device:vacuum:0000A006:viomi-v15:1",),
 )
 
 
@@ -595,4 +598,5 @@ VIOMI_V45 = ModelProfile(
     clean_history=VIOMI_V45_CLEAN_HISTORY,
     dnd=VIOMI_V45_DND,
     voice=VIOMI_V45_VOICE,
+    notes=("urn:miot-spec-v2:device:vacuum:0000A006:viomi-v45:2",),
 )

--- a/custom_components/xiaomi_vac/spec/profiles/xiaomi.py
+++ b/custom_components/xiaomi_vac/spec/profiles/xiaomi.py
@@ -145,6 +145,7 @@ XIAOMI_CORE_D110CH = CoreCapability(
 XIAOMI_B106BK = ModelProfile(
     profile_id='xiaomi.b106bk',
     brand='xiaomi',
+    notes=("urn:miot-spec-v2:device:vacuum:0000A006:xiaomi-b106bk:1",),
     core=XIAOMI_CORE_B106BK,
     map=MapCapability(
         service=10,
@@ -278,6 +279,7 @@ XIAOMI_B106BK = ModelProfile(
 XIAOMI_B108GL = ModelProfile(
     profile_id='xiaomi.b108gl',
     brand='xiaomi',
+    notes=("urn:miot-spec-v2:device:vacuum:0000A006:xiaomi-b108gl:1",),
     core=XIAOMI_CORE_B108GL,
     voice=VoiceCapability(
         service=14,
@@ -295,6 +297,7 @@ XIAOMI_B108GL = ModelProfile(
 XIAOMI_B112 = ModelProfile(
     profile_id='xiaomi.b112',
     brand='xiaomi',
+    notes=("urn:miot-spec-v2:device:vacuum:0000A006:xiaomi-b112:1",),
     core=XIAOMI_CORE_B112,
     map=MapCapability(
         service=10,
@@ -408,6 +411,7 @@ XIAOMI_B112 = ModelProfile(
 XIAOMI_C101 = ModelProfile(
     profile_id='xiaomi.c101',
     brand='xiaomi',
+    notes=("urn:miot-spec-v2:device:vacuum:0000A006:xiaomi-c101:2",),
     core=XIAOMI_CORE_C101,
     map=MapCapability(
         service=10,
@@ -535,6 +539,7 @@ XIAOMI_C101 = ModelProfile(
 XIAOMI_C101EU = ModelProfile(
     profile_id='xiaomi.c101eu',
     brand='xiaomi',
+    notes=("urn:miot-spec-v2:device:vacuum:0000A006:xiaomi-c101eu:2",),
     core=XIAOMI_CORE_C101,
     map=MapCapability(
         service=10,
@@ -666,6 +671,7 @@ XIAOMI_C101EU = ModelProfile(
 XIAOMI_C102CN = ModelProfile(
     profile_id='xiaomi.c102cn',
     brand='xiaomi',
+    notes=("urn:miot-spec-v2:device:vacuum:0000A006:xiaomi-c102cn:1",),
     core=XIAOMI_CORE_C102CN,
     room_clean=RoomCleanCapability(
         room_ids=Prop(2, 4),
@@ -677,6 +683,7 @@ XIAOMI_C102CN = ModelProfile(
 XIAOMI_C104 = ModelProfile(
     profile_id='xiaomi.c104',
     brand='xiaomi',
+    notes=("urn:miot-spec-v2:device:vacuum:0000A006:xiaomi-c104:2",),
     core=XIAOMI_CORE_B106BK,
     map=MapCapability(
         service=10,
@@ -797,7 +804,12 @@ XIAOMI_C104 = ModelProfile(
 
 # xiaomi.vacuum.d110ch — identical RICH layout to C102CN, distinct core
 # (alarm/volume on siid 22). Split so it doesn't inherit C102CN's slots.
-XIAOMI_D110CH = replace(XIAOMI_C102CN, profile_id='xiaomi.d110ch', core=XIAOMI_CORE_D110CH)
+XIAOMI_D110CH = replace(
+    XIAOMI_C102CN,
+    profile_id='xiaomi.d110ch',
+    core=XIAOMI_CORE_D110CH,
+    notes=("urn:miot-spec-v2:device:vacuum:0000A006:xiaomi-d110ch:2",),
+)
 
 # ov21gl / ov71gl — new-generation layout: mode/fan_speed/water_level on siid 2
 # (no siid 7 at all), charging_state on siid 3, alarm/volume on siid 4,
@@ -873,6 +885,7 @@ XIAOMI_CORE_OV21GL = CoreCapability(
 XIAOMI_OV21GL = ModelProfile(
     profile_id='xiaomi.ov21gl',
     brand='xiaomi',
+    notes=("urn:miot-spec-v2:device:vacuum:0000A006:xiaomi-ov21gl:2",),
     core=XIAOMI_CORE_OV21GL,
     room_clean=RoomCleanCapability(
         room_ids=Prop(2, 15),
@@ -881,4 +894,8 @@ XIAOMI_OV21GL = ModelProfile(
 )
 
 # xiaomi.vacuum.ov71gl — identical spec layout to ov21gl
-XIAOMI_OV71GL = replace(XIAOMI_OV21GL, profile_id='xiaomi.ov71gl')
+XIAOMI_OV71GL = replace(
+    XIAOMI_OV21GL,
+    profile_id='xiaomi.ov71gl',
+    notes=("urn:miot-spec-v2:device:vacuum:0000A006:xiaomi-ov71gl:1",),
+)

--- a/custom_components/xiaomi_vac/spec/registry.py
+++ b/custom_components/xiaomi_vac/spec/registry.py
@@ -60,26 +60,26 @@ MODEL_PROFILES: dict[str, ModelProfile] = {
     "ijai.vacuum.v10": IJAI_V10,
     "ijai.vacuum.v13": IJAI_V13,
     "ijai.vacuum.v14": IJAI_V14,
-    "ijai.vacuum.v15": IJAI_V14,
+    "ijai.vacuum.v15": IJAI_V14,  # Alias: spec-verified same layout as ijai.vacuum.v14.
     "ijai.vacuum.v16": IJAI_V16,
     "ijai.vacuum.v17": IJAI_V17,
-    "ijai.vacuum.v18": IJAI_V17,
-    "ijai.vacuum.v19": IJAI_V17,
+    "ijai.vacuum.v18": IJAI_V17,  # Alias: spec-verified same layout as ijai.vacuum.v17.
+    "ijai.vacuum.v19": IJAI_V17,  # Alias: spec-verified same layout as ijai.vacuum.v17.
     # --- xiaomi (ijai-engine rebrands) --------------------------------------
     "xiaomi.vacuum.b106bk": XIAOMI_B106BK,
-    "xiaomi.vacuum.b106eu": XIAOMI_B106BK,
+    "xiaomi.vacuum.b106eu": XIAOMI_B106BK,  # Alias: spec-verified same layout as xiaomi.vacuum.b106bk.
     "xiaomi.vacuum.b108gl": XIAOMI_B108GL,
     "xiaomi.vacuum.b112": XIAOMI_B112,
-    "xiaomi.vacuum.b112bk": XIAOMI_B112,
-    "xiaomi.vacuum.b112gl": XIAOMI_B112,
+    "xiaomi.vacuum.b112bk": XIAOMI_B112,  # Alias: spec-verified same layout as xiaomi.vacuum.b112.
+    "xiaomi.vacuum.b112gl": XIAOMI_B112,  # Alias: spec-verified same layout as xiaomi.vacuum.b112.
     "xiaomi.vacuum.c101": XIAOMI_C101,
     "xiaomi.vacuum.c101eu": XIAOMI_C101EU,
     "xiaomi.vacuum.c102cn": XIAOMI_C102CN,
-    "xiaomi.vacuum.c102gl": XIAOMI_C102CN,
-    "xiaomi.vacuum.c103": XIAOMI_C101,
+    "xiaomi.vacuum.c102gl": XIAOMI_C102CN,  # Alias: spec-verified same layout as xiaomi.vacuum.c102cn.
+    "xiaomi.vacuum.c103": XIAOMI_C101,  # Alias: spec-verified same layout as xiaomi.vacuum.c101.
     "xiaomi.vacuum.c104": XIAOMI_C104,
-    "xiaomi.vacuum.d103cn": XIAOMI_C102CN,
-    "xiaomi.vacuum.d106gl": XIAOMI_C101EU,
+    "xiaomi.vacuum.d103cn": XIAOMI_C102CN,  # Alias: spec-verified same layout as xiaomi.vacuum.c102cn.
+    "xiaomi.vacuum.d106gl": XIAOMI_C101EU,  # Alias: spec-verified same layout as xiaomi.vacuum.c101eu.
     "xiaomi.vacuum.d110ch": XIAOMI_D110CH,
     "xiaomi.vacuum.ov21gl": XIAOMI_OV21GL,
     "xiaomi.vacuum.ov71gl": XIAOMI_OV71GL,
@@ -87,45 +87,45 @@ MODEL_PROFILES: dict[str, ModelProfile] = {
     "viomi.vacuum.v12": VIOMI_V12,
     "viomi.vacuum.v13": VIOMI_V13,
     "viomi.vacuum.v15": VIOMI_V15,
-    "viomi.vacuum.v17": VIOMI_V15,
-    "viomi.vacuum.v18": VIOMI_V15,
-    "viomi.vacuum.v19": VIOMI_V13,
-    "viomi.vacuum.v22": VIOMI_V15,
-    "viomi.vacuum.v23": VIOMI_V15,
-    "viomi.vacuum.v24": VIOMI_V15,
-    "viomi.vacuum.v35": VIOMI_V13,
-    "viomi.vacuum.v38": VIOMI_V15,
-    "viomi.vacuum.v40": VIOMI_V15,
+    "viomi.vacuum.v17": VIOMI_V15,  # Alias: spec-verified same layout as viomi.vacuum.v15.
+    "viomi.vacuum.v18": VIOMI_V15,  # Alias: spec-verified same layout as viomi.vacuum.v15.
+    "viomi.vacuum.v19": VIOMI_V13,  # Alias: spec-verified same layout as viomi.vacuum.v13.
+    "viomi.vacuum.v22": VIOMI_V15,  # Alias: spec-verified same layout as viomi.vacuum.v15.
+    "viomi.vacuum.v23": VIOMI_V15,  # Alias: spec-verified same layout as viomi.vacuum.v15.
+    "viomi.vacuum.v24": VIOMI_V15,  # Alias: spec-verified same layout as viomi.vacuum.v15.
+    "viomi.vacuum.v35": VIOMI_V13,  # Alias: spec-verified same layout as viomi.vacuum.v13.
+    "viomi.vacuum.v38": VIOMI_V15,  # Alias: spec-verified same layout as viomi.vacuum.v15.
+    "viomi.vacuum.v40": VIOMI_V15,  # Alias: spec-verified same layout as viomi.vacuum.v15.
     "viomi.vacuum.v45": VIOMI_V45,
     # --- roidmi -------------------------------------------------------------
     "roidmi.vacuum.r1b": ROIDMI_R1B,
     "roidmi.vacuum.sdj60": ROIDMI_SDJ60,
-    "roidmi.vacuum.v60": ROIDMI_R1B,
+    "roidmi.vacuum.v60": ROIDMI_R1B,  # Alias: spec-verified same layout as roidmi.vacuum.r1b.
     "roidmi.vacuum.v62": ROIDMI_V62,
-    "roidmi.vacuum.v66": ROIDMI_R1B,
+    "roidmi.vacuum.v66": ROIDMI_R1B,  # Alias: spec-verified same layout as roidmi.vacuum.r1b.
     # --- dreame (full rich caps: blob map / brush+filter+mop+detergent /
     #     vacuum-extend / clean-logs / do-not-disturb / audio) -----------------
     "dreame.vacuum.p2008": DREAME_P2008,
     "dreame.vacuum.p2009": DREAME_P2009,
     "dreame.vacuum.p2027": DREAME_P2027,
-    "dreame.vacuum.p2028": DREAME_P2009,
-    "dreame.vacuum.p2028a": DREAME_P2009,
-    "dreame.vacuum.p2029": DREAME_P2009,
+    "dreame.vacuum.p2028": DREAME_P2009,  # Alias: spec-verified same layout as dreame.vacuum.p2009.
+    "dreame.vacuum.p2028a": DREAME_P2009,  # Alias: spec-verified same layout as dreame.vacuum.p2009.
+    "dreame.vacuum.p2029": DREAME_P2009,  # Alias: spec-verified same layout as dreame.vacuum.p2009.
     "dreame.vacuum.p2036": DREAME_P2036,
     "dreame.vacuum.p2114a": DREAME_P2114A,
     "dreame.vacuum.p2114o": DREAME_P2114O,
-    "dreame.vacuum.p2140": DREAME_P2036,
-    "dreame.vacuum.p2140a": DREAME_P2036,
-    "dreame.vacuum.p2140p": DREAME_P2036,
-    "dreame.vacuum.p2148o": DREAME_P2036,
+    "dreame.vacuum.p2140": DREAME_P2036,  # Alias: spec-verified same layout as dreame.vacuum.p2036.
+    "dreame.vacuum.p2140a": DREAME_P2036,  # Alias: spec-verified same layout as dreame.vacuum.p2036.
+    "dreame.vacuum.p2140p": DREAME_P2036,  # Alias: spec-verified same layout as dreame.vacuum.p2036.
+    "dreame.vacuum.p2148o": DREAME_P2036,  # Alias: spec-verified same layout as dreame.vacuum.p2036.
     "dreame.vacuum.p2149o": DREAME_P2149O,
     "dreame.vacuum.p2150a": DREAME_P2150A,
-    "dreame.vacuum.p2150b": DREAME_P2009,
-    "dreame.vacuum.p2150o": DREAME_P2036,
-    "dreame.vacuum.p2157": DREAME_P2036,
-    "dreame.vacuum.p2187": DREAME_P2009,
-    "dreame.vacuum.p2259": DREAME_P2009,
-    "dreame.vacuum.r2104": DREAME_P2027,
+    "dreame.vacuum.p2150b": DREAME_P2009,  # Alias: spec-verified same layout as dreame.vacuum.p2009.
+    "dreame.vacuum.p2150o": DREAME_P2036,  # Alias: spec-verified same layout as dreame.vacuum.p2036.
+    "dreame.vacuum.p2157": DREAME_P2036,  # Alias: spec-verified same layout as dreame.vacuum.p2036.
+    "dreame.vacuum.p2187": DREAME_P2009,  # Alias: spec-verified same layout as dreame.vacuum.p2009.
+    "dreame.vacuum.p2259": DREAME_P2009,  # Alias: spec-verified same layout as dreame.vacuum.p2009.
+    "dreame.vacuum.r2104": DREAME_P2027,  # Alias: spec-verified same layout as dreame.vacuum.p2027.
     "dreame.vacuum.r2205": DREAME_R2205,
     "dreame.vacuum.r2209": DREAME_R2209,
     "dreame.vacuum.r2210": DREAME_R2210,
@@ -133,17 +133,17 @@ MODEL_PROFILES: dict[str, ModelProfile] = {
     "dreame.vacuum.r2215": DREAME_R2215,
     "dreame.vacuum.r2216o": DREAME_R2216O,
     "dreame.vacuum.r2228": DREAME_R2228,
-    "dreame.vacuum.r2228o": DREAME_R2215,
-    "dreame.vacuum.r2228z": DREAME_R2215,
-    "dreame.vacuum.r2232a": DREAME_R2215,
-    "dreame.vacuum.r2233": DREAME_R2215,
-    "dreame.vacuum.r2235": DREAME_R2215,
+    "dreame.vacuum.r2228o": DREAME_R2215,  # Alias: spec-verified same layout as dreame.vacuum.r2215.
+    "dreame.vacuum.r2228z": DREAME_R2215,  # Alias: spec-verified same layout as dreame.vacuum.r2215.
+    "dreame.vacuum.r2232a": DREAME_R2215,  # Alias: spec-verified same layout as dreame.vacuum.r2215.
+    "dreame.vacuum.r2233": DREAME_R2215,  # Alias: spec-verified same layout as dreame.vacuum.r2215.
+    "dreame.vacuum.r2235": DREAME_R2215,  # Alias: spec-verified same layout as dreame.vacuum.r2215.
     "dreame.vacuum.r2235a": DREAME_R2235A,
-    "dreame.vacuum.r2246": DREAME_R2215,
-    "dreame.vacuum.r2247": DREAME_R2215,
+    "dreame.vacuum.r2246": DREAME_R2215,  # Alias: spec-verified same layout as dreame.vacuum.r2215.
+    "dreame.vacuum.r2247": DREAME_R2215,  # Alias: spec-verified same layout as dreame.vacuum.r2215.
     "dreame.vacuum.r2254": DREAME_R2254,
     "dreame.vacuum.r2257o": DREAME_R2257O,
-    "dreame.vacuum.r2312": DREAME_R2235A,
+    "dreame.vacuum.r2312": DREAME_R2235A,  # Alias: spec-verified same layout as dreame.vacuum.r2235a.
 }
 
 

--- a/custom_components/xiaomi_vac/spec/registry.py
+++ b/custom_components/xiaomi_vac/spec/registry.py
@@ -10,6 +10,7 @@ from .profiles.dreame import (
     DREAME_P2009,
     DREAME_P2027,
     DREAME_P2036,
+    DREAME_P2041,
     DREAME_P2114A,
     DREAME_P2114O,
     DREAME_P2149O,
@@ -112,10 +113,13 @@ MODEL_PROFILES: dict[str, ModelProfile] = {
     "dreame.vacuum.p2028a": DREAME_P2009,  # Alias: spec-verified same layout as dreame.vacuum.p2009.
     "dreame.vacuum.p2029": DREAME_P2009,  # Alias: spec-verified same layout as dreame.vacuum.p2009.
     "dreame.vacuum.p2036": DREAME_P2036,
+    "dreame.vacuum.p2041": DREAME_P2041,
+    "dreame.vacuum.p2041o": DREAME_P2041,  # Alias: spec-verified same layout as dreame.vacuum.p2041.
     "dreame.vacuum.p2114a": DREAME_P2114A,
     "dreame.vacuum.p2114o": DREAME_P2114O,
     "dreame.vacuum.p2140": DREAME_P2036,  # Alias: spec-verified same layout as dreame.vacuum.p2036.
     "dreame.vacuum.p2140a": DREAME_P2036,  # Alias: spec-verified same layout as dreame.vacuum.p2036.
+    "dreame.vacuum.p2140o": DREAME_P2041,  # Alias: spec-verified same layout as dreame.vacuum.p2041.
     "dreame.vacuum.p2140p": DREAME_P2036,  # Alias: spec-verified same layout as dreame.vacuum.p2036.
     "dreame.vacuum.p2148o": DREAME_P2036,  # Alias: spec-verified same layout as dreame.vacuum.p2036.
     "dreame.vacuum.p2149o": DREAME_P2149O,

--- a/custom_components/xiaomi_vac/strings.json
+++ b/custom_components/xiaomi_vac/strings.json
@@ -55,14 +55,23 @@
       },
       "miot_oauth_auth": {
         "title": "Link Xiaomi OAuth",
-        "description": "Open this link, approve access, then paste the code from the redirect address bar:\n\n{authorize_url}",
+        "description": "Open the Xiaomi OAuth link. Home Assistant will continue automatically after Xiaomi redirects back.",
+        "data": {}
+      },
+      "miot_oauth_code": {
+        "title": "Paste Xiaomi OAuth code",
+        "description": "The automatic callback did not finish. Open this link, approve access, then paste the code from the redirect address bar (after 'CODE=' and before '&'):\n\n{authorize_url}",
         "data": {
           "code": "OAuth code"
         }
       },
+      "miot_oauth_finish": {
+        "title": "Xiaomi OAuth linked",
+        "description": "The real-time map auth is ready."
+      },
       "reauth_confirm": {
         "title": "Sign in to Xiaomi again",
-        "description": "Your session ran out and couldn't renew on its own. Sign in again to bring the live map back.",
+        "description": "Your Xiaomi cloud map session ran out and couldn't renew on its own. Sign in again to bring the map back.",
         "data": {
           "username": "Email, phone number or Mi account ID",
           "password": "Password"
@@ -72,13 +81,16 @@
     "error": {
       "unsupported_model": "This model isn't supported yet.",
       "cannot_connect": "Couldn't reach the vacuum at that IP with that token.",
-      "oauth_failed": "Xiaomi OAuth failed. Start the link again and paste the new code.",
+      "oauth_failed": "Xiaomi OAuth failed. Try the link again or paste the code manually.",
       "oauth_region_failed": "Couldn't work out the Xiaomi OAuth region from that code."
+    },
+    "progress": {
+      "miot_oauth_auth": "Open [Xiaomi OAuth]({authorize_url}) in a new tab. After approval, Xiaomi should return to Home Assistant and this step will continue automatically."
     },
     "abort": {
       "already_configured": "This vacuum is already set up.",
       "reauth_successful": "You're back in. The live map's restored.",
-      "login_failed": "Xiaomi wouldn't accept that. Check your email and password, then try again.",
+      "login_failed": "Xiaomi cloud sign-in failed. Check your email and password, then try again.",
       "no_devices": "No supported vacuums on this account.",
       "unsupported_model": "This model isn't supported yet (ijai / Xiaomi-branded ijai vacuums only)."
     }
@@ -87,15 +99,27 @@
     "step": {
       "miot_oauth_auth": {
         "title": "Link Xiaomi OAuth",
-        "description": "Enable the real-time (MQTT) live map on this existing vacuum. Open this link, approve access, then paste the code from the redirect address bar:\n\n{authorize_url}",
+        "description": "Open the Xiaomi OAuth link. Home Assistant will continue automatically after Xiaomi redirects back.",
+        "data": {}
+      },
+      "miot_oauth_code": {
+        "title": "Paste Xiaomi OAuth code",
+        "description": "The automatic callback did not finish. Open this link, approve access, then paste the code from the redirect address bar:\n\n{authorize_url}",
         "data": {
           "code": "OAuth code"
         }
+      },
+      "miot_oauth_finish": {
+        "title": "Xiaomi OAuth linked",
+        "description": "The real-time map auth is ready."
       }
     },
     "error": {
-      "oauth_failed": "Xiaomi OAuth failed. Start the link again and paste the new code.",
+      "oauth_failed": "Xiaomi OAuth failed. Try the link again or paste the code manually.",
       "oauth_region_failed": "Couldn't work out the Xiaomi OAuth region from that code."
+    },
+    "progress": {
+      "miot_oauth_auth": "Open [Xiaomi OAuth]({authorize_url}) in a new tab. After approval, Xiaomi should return to Home Assistant and this step will continue automatically."
     },
     "abort": {
       "oauth_local_only": "This vacuum was added as local-only, so it has no Xiaomi cloud session to link OAuth to."
@@ -192,7 +216,9 @@
           "two": "Two",
           "three": "Three",
           "forth": "Forth",
-          "silent": "Silent"
+          "silent": "Silent",
+          "basic": "Basic",
+          "full_speed": "Full Speed"
         }
       },
       "water_level": {
@@ -217,7 +243,11 @@
           "one": "One",
           "two": "Two",
           "three": "Three",
-          "hig": "High"
+          "hig": "High",
+          "off": "Off",
+          "level1": "Level 1",
+          "level2": "Level 2",
+          "level3": "Level 3"
         }
       },
       "mode": {
@@ -233,7 +263,9 @@
           "mop": "Mopping",
           "medium": "Medium Gear",
           "sweepandmop": "Sweep and Mop",
-          "sweep_then_mop": "Sweep Then Mop"
+          "sweep_then_mop": "Sweep Then Mop",
+          "sweep_mop": "Sweep and Mop",
+          "sweep_before_mopping": "Sweep Before Mopping"
         }
       },
       "sweep_type": {
@@ -262,8 +294,15 @@
           "selectroom": "Room",
           "customclean": "Custom Cleaning",
           "costum": "Custom",
-          "custom_area": "Custom Area"
+          "custom_area": "Custom Area",
+          "appointment": "Scheduled",
+          "linkage": "Linkage",
+          "fast": "Fast",
+          "ai_hosting": "AI Hosting"
         }
+      },
+      "active_map": {
+        "name": "Active map"
       }
     },
     "switch": {

--- a/custom_components/xiaomi_vac/strings.json
+++ b/custom_components/xiaomi_vac/strings.json
@@ -90,7 +90,8 @@
     "abort": {
       "already_configured": "This vacuum is already set up.",
       "reauth_successful": "You're back in. The live map's restored.",
-      "login_failed": "Xiaomi cloud sign-in failed. Check your email and password, then try again.",
+      "login_failed": "Xiaomi cloud sign-in failed ({reason}). Check your email and password, then try again.",
+      "login_verification_required": "Xiaomi blocked this sign-in and wants the account verified. Sign in at account.xiaomi.com (or the Xiaomi Home app), complete any verification it asks for, then try again.",
       "no_devices": "No supported vacuums on this account.",
       "unsupported_model": "This model isn't supported yet (ijai / Xiaomi-branded ijai vacuums only)."
     }

--- a/custom_components/xiaomi_vac/translations/en.json
+++ b/custom_components/xiaomi_vac/translations/en.json
@@ -90,7 +90,8 @@
     "abort": {
       "already_configured": "This vacuum is already set up.",
       "reauth_successful": "You're back in. The live map's restored.",
-      "login_failed": "Xiaomi cloud sign-in failed. Check your email and password, then try again.",
+      "login_failed": "Xiaomi cloud sign-in failed ({reason}). Check your email and password, then try again.",
+      "login_verification_required": "Xiaomi blocked this sign-in and wants the account verified. Sign in at account.xiaomi.com (or the Xiaomi Home app), complete any verification it asks for, then try again.",
       "no_devices": "No supported vacuums on this account.",
       "unsupported_model": "This model isn't supported yet (ijai / Xiaomi-branded ijai vacuums only)."
     }

--- a/custom_components/xiaomi_vac/translations/en.json
+++ b/custom_components/xiaomi_vac/translations/en.json
@@ -46,9 +46,32 @@
           "device": "Vacuum"
         }
       },
+      "miot_oauth": {
+        "title": "Enable real-time map auth",
+        "description": "Optional. This prepares the live MQTT map path. Skip it to keep the current polling map behaviour.",
+        "data": {
+          "enable_miot_oauth": "Enable OAuth for real-time map updates"
+        }
+      },
+      "miot_oauth_auth": {
+        "title": "Link Xiaomi OAuth",
+        "description": "Open the Xiaomi OAuth link. Home Assistant will continue automatically after Xiaomi redirects back.",
+        "data": {}
+      },
+      "miot_oauth_code": {
+        "title": "Paste Xiaomi OAuth code",
+        "description": "The automatic callback did not finish. Open this link, approve access, then paste the code from the redirect address bar (after 'CODE=' and before '&'):\n\n{authorize_url}",
+        "data": {
+          "code": "OAuth code"
+        }
+      },
+      "miot_oauth_finish": {
+        "title": "Xiaomi OAuth linked",
+        "description": "The real-time map auth is ready."
+      },
       "reauth_confirm": {
         "title": "Sign in to Xiaomi again",
-        "description": "Your session ran out and couldn't renew on its own. Sign in again to bring the live map back.",
+        "description": "Your Xiaomi cloud map session ran out and couldn't renew on its own. Sign in again to bring the map back.",
         "data": {
           "username": "Email, phone number or Mi account ID",
           "password": "Password"
@@ -57,12 +80,17 @@
     },
     "error": {
       "unsupported_model": "This model isn't supported yet.",
-      "cannot_connect": "Couldn't reach the vacuum at that IP with that token."
+      "cannot_connect": "Couldn't reach the vacuum at that IP with that token.",
+      "oauth_failed": "Xiaomi OAuth failed. Try the link again or paste the code manually.",
+      "oauth_region_failed": "Couldn't work out the Xiaomi OAuth region from that code."
+    },
+    "progress": {
+      "miot_oauth_auth": "Open [Xiaomi OAuth]({authorize_url}) in a new tab. After approval, Xiaomi should return to Home Assistant and this step will continue automatically."
     },
     "abort": {
       "already_configured": "This vacuum is already set up.",
       "reauth_successful": "You're back in. The live map's restored.",
-      "login_failed": "Xiaomi wouldn't accept that. Check your email and password, then try again.",
+      "login_failed": "Xiaomi cloud sign-in failed. Check your email and password, then try again.",
       "no_devices": "No supported vacuums on this account.",
       "unsupported_model": "This model isn't supported yet (ijai / Xiaomi-branded ijai vacuums only)."
     }
@@ -71,15 +99,27 @@
     "step": {
       "miot_oauth_auth": {
         "title": "Link Xiaomi OAuth",
-        "description": "Enable the real-time (MQTT) live map on this existing vacuum. Open this link, approve access, then paste the code from the redirect address bar:\n\n{authorize_url}",
+        "description": "Open the Xiaomi OAuth link. Home Assistant will continue automatically after Xiaomi redirects back.",
+        "data": {}
+      },
+      "miot_oauth_code": {
+        "title": "Paste Xiaomi OAuth code",
+        "description": "The automatic callback did not finish. Open this link, approve access, then paste the code from the redirect address bar:\n\n{authorize_url}",
         "data": {
           "code": "OAuth code"
         }
+      },
+      "miot_oauth_finish": {
+        "title": "Xiaomi OAuth linked",
+        "description": "The real-time map auth is ready."
       }
     },
     "error": {
-      "oauth_failed": "Xiaomi OAuth failed. Start the link again and paste the new code.",
+      "oauth_failed": "Xiaomi OAuth failed. Try the link again or paste the code manually.",
       "oauth_region_failed": "Couldn't work out the Xiaomi OAuth region from that code."
+    },
+    "progress": {
+      "miot_oauth_auth": "Open [Xiaomi OAuth]({authorize_url}) in a new tab. After approval, Xiaomi should return to Home Assistant and this step will continue automatically."
     },
     "abort": {
       "oauth_local_only": "This vacuum was added as local-only, so it has no Xiaomi cloud session to link OAuth to."

--- a/custom_components/xiaomi_vac/vacuum.py
+++ b/custom_components/xiaomi_vac/vacuum.py
@@ -16,8 +16,19 @@ from homeassistant.helpers.entity_platform import AddEntitiesCallback
 from homeassistant.helpers.update_coordinator import CoordinatorEntity
 
 from . import XiaomiConfigEntry
-from .const import DOMAIN
+from .cloud.connector import XiaomiCloud
+from .const import (
+    CONF_DEVICE_ID,
+    CONF_PASS_TOKEN,
+    CONF_SERVER,
+    CONF_SERVICE_TOKEN,
+    CONF_SSECURITY,
+    CONF_USER_ID,
+    CONF_USERNAME,
+    DOMAIN,
+)
 from .coordinator import XiaomiVacuumCoordinator
+from .device import IjaiVacuumDevice
 
 # Serialise commands to the device (one MIoT write at a time).
 PARALLEL_UPDATES = 1
@@ -37,6 +48,8 @@ _BASE_SUPPORT = (
     | VacuumEntityFeature.STOP
     | VacuumEntityFeature.STATE
 )
+
+_USER_ACK_TIMEOUT = "-9999"
 
 
 async def async_setup_entry(
@@ -120,5 +133,77 @@ class XiaomiVacuum(CoordinatorEntity[XiaomiVacuumCoordinator], StateVacuumEntity
 
     async def async_clean_segment(self, segments: list[int]) -> None:
         """Clean one or more rooms by their map room id (tap-to-clean)."""
-        await self.hass.async_add_executor_job(self._device.clean_segments, segments)
+        try:
+            await self.hass.async_add_executor_job(self._device.clean_segments, segments)
+        except Exception as err:  # noqa: BLE001
+            if not _is_user_ack_timeout(err):
+                raise HomeAssistantError(f"Room cleaning failed: {err}") from err
+            try:
+                await self.hass.async_add_executor_job(
+                    _cloud_clean_segments, self._entry.data, self._device, segments
+                )
+            except Exception as cloud_err:  # noqa: BLE001
+                raise HomeAssistantError(
+                    f"Room cleaning timed out locally and cloud fallback failed: {cloud_err}"
+                ) from cloud_err
         await self.coordinator.async_request_refresh()
+
+
+def _is_user_ack_timeout(err: Exception) -> bool:
+    return any(_USER_ACK_TIMEOUT in str(part) for part in (*err.args, err))
+
+
+def _cloud_action_ok(response: object) -> bool:
+    if not isinstance(response, dict):
+        return False
+    if response.get("code", 0) != 0:
+        return False
+    result = response.get("result")
+    if isinstance(result, dict) and result.get("code", 0) != 0:
+        return False
+    if isinstance(result, list):
+        return all(not isinstance(item, dict) or item.get("code", 0) == 0 for item in result)
+    return True
+
+
+def _cloud_clean_segments(data: dict, device: IjaiVacuumDevice, segments: list[int]) -> None:
+    required = (
+        data.get(CONF_USERNAME),
+        data.get(CONF_USER_ID),
+        data.get(CONF_SSECURITY),
+        data.get(CONF_SERVICE_TOKEN),
+        data.get(CONF_SERVER),
+        data.get(CONF_DEVICE_ID),
+    )
+    if not all(required):
+        raise ValueError("Room cleaning cloud fallback requires a Xiaomi cloud session")
+
+    attempts = [
+        params
+        for params in (
+            device.room_clean_start_params(segments),
+            device.room_clean_set_params(segments),
+        )
+        if params is not None
+    ]
+    if not attempts:
+        raise ValueError(f"{device.model} has no supported room-clean action")
+
+    cloud = XiaomiCloud(str(data[CONF_USERNAME]))
+    cloud.restore_session(
+        data[CONF_USER_ID],
+        data[CONF_SSECURITY],
+        data[CONF_SERVICE_TOKEN],
+        data.get(CONF_PASS_TOKEN),
+    )
+    for action, params in attempts:
+        response = cloud.cloud_action(
+            str(data[CONF_SERVER]),
+            str(data[CONF_DEVICE_ID]),
+            action.siid,
+            action.aiid,
+            params,
+        )
+        if _cloud_action_ok(response):
+            return
+    raise ValueError("Xiaomi cloud rejected every room-clean action")

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,5 +1,7 @@
 [pytest]
 asyncio_mode = auto
+testpaths = tests
+norecursedirs = ha_xiaomi_home venv
 markers =
     pure: pure tests that do not require Home Assistant
     harness: Home Assistant harness tests

--- a/tests/harness/test_config_flow.py
+++ b/tests/harness/test_config_flow.py
@@ -1,5 +1,8 @@
 """Tests for the Xiaomi Vacuum config flow."""
+import asyncio
+import json
 from contextlib import ExitStack
+from pathlib import Path
 from unittest.mock import patch
 
 import pytest
@@ -9,7 +12,6 @@ from homeassistant.data_entry_flow import FlowResultType
 from pytest_homeassistant_custom_component.common import MockConfigEntry
 
 from custom_components.xiaomi_vac import async_migrate_entry
-from custom_components.xiaomi_vac.cloud.oauth import OAuthTokenSet
 from custom_components.xiaomi_vac.const import (
     CONF_HOST,
     CONF_MODEL,
@@ -18,6 +20,8 @@ from custom_components.xiaomi_vac.const import (
     CONF_OAUTH_EXPIRES_TS,
     CONF_OAUTH_REFRESH_TOKEN,
     CONF_OAUTH_REGION,
+    CONF_OAUTH_REDIRECT_URI,
+    CONF_PASS_TOKEN,
     CONF_PASSWORD,
     CONF_SERVICE_TOKEN,
     CONF_SSECURITY,
@@ -28,6 +32,13 @@ from custom_components.xiaomi_vac.const import (
 )
 
 TOKEN = "0" * 32
+TRANSLATIONS_EN = (
+    Path(__file__).resolve().parents[2]
+    / "custom_components"
+    / "xiaomi_vac"
+    / "translations"
+    / "en.json"
+)
 
 @pytest.fixture(autouse=True)
 def mock_setup_entry():
@@ -237,37 +248,59 @@ async def test_cloud_oauth_skip_keeps_legacy_entry_data(hass: HomeAssistant) -> 
 
 
 async def test_cloud_oauth_success_stores_miot_tokens(hass: HomeAssistant) -> None:
-    """Opting into MIoT OAuth stores the token set for the future MQTT client."""
+    """Opting into MIoT OAuth links through HA's webhook progress flow."""
     result = await _credentials_to_devices(
         hass, [_make_device("dreame.vacuum.p2008")], stop_at_oauth=True
     )
-    result = await hass.config_entries.flow.async_configure(
-        result["flow_id"], {"enable_miot_oauth": True}
-    )
-    assert result["type"] is FlowResultType.FORM
-    assert result["step_id"] == "miot_oauth_auth"
+    updates = {
+        CONF_OAUTH_ACCESS_TOKEN: "access",
+        CONF_OAUTH_REFRESH_TOKEN: "refresh",
+        CONF_OAUTH_EXPIRES_TS: 1234,
+        CONF_OAUTH_REGION: "sg",
+        CONF_OAUTH_DEVICE_ID: "ha.webhook",
+        CONF_OAUTH_REDIRECT_URI: "http://homeassistant.local:8123/api/webhook/abc",
+    }
+    async def _slow_exchange(*args, **kwargs):
+        # Yield once so the eagerly-started task is still pending when the
+        # flow renders the progress step (the real exchange awaits a webhook).
+        await asyncio.sleep(0)
+        return updates
 
-    tokens = OAuthTokenSet(
-        access_token="access",
-        refresh_token="refresh",
-        expires_in=3600,
-        expires_ts=1234,
-        region="sg",
-    )
     with patch(
-        "custom_components.xiaomi_vac.config_flow.exchange_code",
-        return_value=tokens,
+        "custom_components.xiaomi_vac.config_flow._async_exchange_linked_oauth",
+        side_effect=_slow_exchange,
     ):
         result = await hass.config_entries.flow.async_configure(
-            result["flow_id"], {"code": "ALSG_code"}
+            result["flow_id"], {"enable_miot_oauth": True}
         )
+        assert result["type"] is FlowResultType.SHOW_PROGRESS
+        authorize_url = result["description_placeholders"]["authorize_url"]
+        assert "account.xiaomi.com/oauth2/authorize" in authorize_url
+        # redirect_uri is percent-encoded inside the authorize URL
+        assert "%2Fapi%2Fwebhook%2F" in authorize_url
+
+        # HA auto-advances through show_progress_done once the task finishes
+        await asyncio.sleep(0)
+        result = await hass.config_entries.flow.async_configure(result["flow_id"])
 
     assert result["type"] is FlowResultType.CREATE_ENTRY
     assert result["data"][CONF_OAUTH_ACCESS_TOKEN] == "access"
     assert result["data"][CONF_OAUTH_REFRESH_TOKEN] == "refresh"
     assert result["data"][CONF_OAUTH_EXPIRES_TS] == 1234
     assert result["data"][CONF_OAUTH_REGION] == "sg"
-    assert result["data"][CONF_OAUTH_DEVICE_ID].startswith("ha.")
+    assert result["data"][CONF_OAUTH_DEVICE_ID] == "ha.webhook"
+    assert result["data"][CONF_OAUTH_REDIRECT_URI].endswith("/api/webhook/abc")
+
+
+def test_generated_english_translation_contains_oauth_config_step() -> None:
+    """translations/en.json must include the config-flow OAuth link step."""
+    doc = json.loads(TRANSLATIONS_EN.read_text(encoding="utf-8"))
+
+    step = doc["config"]["step"]["miot_oauth_code"]
+
+    assert "{authorize_url}" in step["description"]
+    assert step["data"]["code"] == "OAuth code"
+    assert "{authorize_url}" in doc["config"]["progress"]["miot_oauth_auth"]
 
 
 async def test_reauth_mints_tokens_and_discards_password(hass: HomeAssistant) -> None:
@@ -312,6 +345,8 @@ async def test_reauth_mints_tokens_and_discards_password(hass: HomeAssistant) ->
     assert result["reason"] == "reauth_successful"
     assert CONF_PASSWORD not in entry.data
     assert entry.data[CONF_SERVICE_TOKEN] == "newtoken"
+    assert entry.data[CONF_SSECURITY] == "newsec"
+    assert entry.data[CONF_PASS_TOKEN] == "newpass"
     assert entry.data[CONF_USER_ID] == "new"
 
 

--- a/tests/harness/test_coordinator.py
+++ b/tests/harness/test_coordinator.py
@@ -175,6 +175,60 @@ async def test_map_coordinator_build_ijai_raises_without_wifi_sn(
         coord._build()
 
 
+async def test_map_coordinator_persists_live_wifi_sn_and_mac(
+    hass: HomeAssistant,
+) -> None:
+    """Live non-empty map key inputs are saved back to the config entry."""
+    entry = _map_entry("ijai.vacuum.v17")
+    device = MagicMock()
+    device.profile = SimpleNamespace(brand="ijai", profile_id="ijai.v17", map=None)
+    device.get_wifi_sn.return_value = "A" * 18
+    device.get_mac.return_value = "AA:BB:CC:DD:EE:FF"
+    control = MagicMock()
+    control.data = None
+    coord = XiaomiMapCoordinator(hass, entry, device, control)
+
+    with (
+        patch("custom_components.xiaomi_vac.map_coordinator.XiaomiCloud"),
+        patch("custom_components.xiaomi_vac.map_coordinator.MapFetcher"),
+        patch.object(hass.config_entries, "async_update_entry") as update,
+    ):
+        coord._build()
+        coord._persist_pending_entry_updates()
+
+    updated = update.call_args.kwargs["data"]
+    assert updated[CONF_WIFI_SN] == "A" * 18
+    assert updated[CONF_MAC] == "AA:BB:CC:DD:EE:FF"
+
+
+async def test_map_coordinator_never_overwrites_stored_keys_with_blank_live_reads(
+    hass: HomeAssistant,
+) -> None:
+    """Blank live reads fall back to stored wifi_sn/mac without persisting blanks."""
+    entry = _map_entry("ijai.vacuum.v17")
+    entry.data[CONF_WIFI_SN] = "B" * 18
+    entry.data[CONF_MAC] = "11:22:33:44:55:66"
+    device = MagicMock()
+    device.profile = SimpleNamespace(brand="ijai", profile_id="ijai.v17", map=None)
+    device.get_wifi_sn.return_value = ""
+    device.get_mac.return_value = None
+    control = MagicMock()
+    control.data = None
+    coord = XiaomiMapCoordinator(hass, entry, device, control)
+
+    with (
+        patch("custom_components.xiaomi_vac.map_coordinator.XiaomiCloud"),
+        patch("custom_components.xiaomi_vac.map_coordinator.MapFetcher") as fetcher,
+        patch.object(hass.config_entries, "async_update_entry") as update,
+    ):
+        coord._build()
+        coord._persist_pending_entry_updates()
+
+    assert fetcher.call_args.kwargs["wifi_sn"] == "B" * 18
+    assert fetcher.call_args.kwargs["mac"] == "11:22:33:44:55:66"
+    update.assert_not_called()
+
+
 # ---------------------------------------------------------------------------
 # Map coordinator: _async_update_data advanced paths
 # ---------------------------------------------------------------------------
@@ -591,6 +645,51 @@ async def test_mqtt_upload_event_schedules_debounce_task(hass: HomeAssistant) ->
 
     assert coord._mqtt_debounce_task is not None
     coord._mqtt_debounce_task.cancel()  # tidy up
+
+
+async def test_map_upload_request_uses_active_map_and_throttles(
+    hass: HomeAssistant,
+) -> None:
+    """Coordinator upload requests use the active map id and throttle repeats."""
+    coord = _map_coord(hass)
+    coord._map_list_meta = [{"id": 7, "cur": True, "name": "Upstairs"}]
+
+    async def _exec(fn, *args):
+        return fn(*args)
+
+    with (
+        patch.object(hass, "async_add_executor_job", new=AsyncMock(side_effect=_exec)),
+        patch("custom_components.xiaomi_vac.map_coordinator.time.monotonic",
+              side_effect=[100.0, 101.0]),
+    ):
+        first = await coord.async_request_map_upload()
+        second = await coord.async_request_map_upload()
+
+    assert first is True
+    assert second is False
+    coord._device.request_map_upload.assert_called_once_with(7)
+
+
+async def test_mqtt_curmap_event_uploads_selected_map_and_refreshes(
+    hass: HomeAssistant,
+) -> None:
+    """MQTT curMapId changes trigger one upload wrapper call and one refresh."""
+    coord = _map_coord(hass)
+    coord.async_refresh = AsyncMock()
+
+    async def _exec(fn, *args):
+        return fn(*args)
+
+    msg = MqttMessage(kind="property", topic="x", siid=10, piid=2, value=7)
+    with (
+        patch("custom_components.xiaomi_vac.map_coordinator._DEBOUNCE_SECONDS", 0),
+        patch.object(hass, "async_add_executor_job", new=AsyncMock(side_effect=_exec)),
+    ):
+        await coord.async_on_mqtt_message(msg)
+        await asyncio.sleep(0.05)
+
+    coord._device.request_map_upload.assert_called_once_with(7)
+    coord.async_refresh.assert_awaited_once()
 
 
 async def test_mqtt_curmap_property_updates_active_id(hass: HomeAssistant) -> None:

--- a/tests/harness/test_entity_platforms.py
+++ b/tests/harness/test_entity_platforms.py
@@ -1,6 +1,7 @@
 """Harness tests: entity construction, feature flags, command dispatch."""
 from __future__ import annotations
 
+from types import SimpleNamespace
 from unittest.mock import AsyncMock, MagicMock, call, patch
 
 import pytest
@@ -11,7 +12,17 @@ from homeassistant.helpers.update_coordinator import UpdateFailed
 
 from custom_components.xiaomi_vac.device import VacuumStatus
 from custom_components.xiaomi_vac.number import VolumeNumber, async_setup_entry as number_setup
+from custom_components.xiaomi_vac.const import (
+    CONF_DEVICE_ID,
+    CONF_PASS_TOKEN,
+    CONF_SERVER,
+    CONF_SERVICE_TOKEN,
+    CONF_SSECURITY,
+    CONF_USER_ID,
+    CONF_USERNAME,
+)
 from custom_components.xiaomi_vac.select import (
+    XiaomiActiveMapSelect,
     XiaomiVacuumSelect,
     async_setup_entry as select_setup,
 )
@@ -306,6 +317,69 @@ async def test_vacuum_clean_segment_calls_device_and_refreshes(hass: HomeAssista
     coord.async_request_refresh.assert_awaited_once()
 
 
+async def test_vacuum_clean_segment_retries_user_ack_timeout_via_cloud(
+    hass: HomeAssistant,
+) -> None:
+    coord = _make_coordinator()
+    coord.device.clean_segments.side_effect = RuntimeError("-9999 user ack timeout")
+    coord.device.room_clean_start_params.return_value = (
+        SimpleNamespace(siid=2, aiid=7),
+        ["1,2"],
+    )
+    coord.device.room_clean_set_params.return_value = (
+        SimpleNamespace(siid=7, aiid=3),
+        [0, 1, "1,2"],
+    )
+    coord.async_request_refresh = AsyncMock()
+    entry = _make_entry()
+    entry.data = {
+        CONF_USERNAME: "user@example.com",
+        CONF_USER_ID: "uid",
+        CONF_SSECURITY: "ssec",
+        CONF_SERVICE_TOKEN: "svc",
+        CONF_PASS_TOKEN: "pass",
+        CONF_SERVER: "sg",
+        CONF_DEVICE_ID: "did123",
+    }
+    vac = XiaomiVacuum(coord, entry)
+    vac.hass = hass
+
+    cloud = MagicMock()
+    cloud.cloud_action.side_effect = [{"code": -1}, {"code": 0}]
+    with patch("custom_components.xiaomi_vac.vacuum.XiaomiCloud", return_value=cloud):
+        await vac.async_clean_segment(segments=[1, 2])
+
+    coord.device.clean_segments.assert_called_once_with([1, 2])
+    cloud.cloud_action.assert_has_calls(
+        [
+            call("sg", "did123", 2, 7, ["1,2"]),
+            call("sg", "did123", 7, 3, [0, 1, "1,2"]),
+        ]
+    )
+    coord.async_request_refresh.assert_awaited_once()
+
+
+async def test_vacuum_clean_segment_does_not_cloud_retry_other_failures(
+    hass: HomeAssistant,
+) -> None:
+    coord = _make_coordinator()
+    coord.device.clean_segments.side_effect = RuntimeError("boom")
+    coord.async_request_refresh = AsyncMock()
+    entry = _make_entry()
+    entry.data = {}
+    vac = XiaomiVacuum(coord, entry)
+    vac.hass = hass
+
+    with (
+        patch("custom_components.xiaomi_vac.vacuum.XiaomiCloud") as cloud_cls,
+        pytest.raises(HomeAssistantError, match="Room cleaning failed"),
+    ):
+        await vac.async_clean_segment(segments=[1, 2])
+
+    cloud_cls.assert_not_called()
+    coord.async_request_refresh.assert_not_awaited()
+
+
 # ---------------------------------------------------------------------------
 # Command dispatch: select entity
 # ---------------------------------------------------------------------------
@@ -322,6 +396,31 @@ async def test_select_option_calls_setter_and_refreshes(hass: HomeAssistant) -> 
     await sel.async_select_option("normal")
 
     coord.device.set_fan_speed.assert_called_once_with("normal")
+    coord.async_request_refresh.assert_awaited_once()
+
+
+async def test_active_map_select_options_current_and_switch_uploads(
+    hass: HomeAssistant,
+) -> None:
+    coord = MagicMock()
+    coord.map_list_meta = [
+        {"id": 1, "name": "Ground", "cur": True},
+        {"id": 2, "name": "Upstairs", "cur": False},
+    ]
+    coord.async_request_map_upload = AsyncMock()
+    coord.async_request_refresh = AsyncMock()
+    entry = _make_entry()
+
+    sel = XiaomiActiveMapSelect(coord, entry)
+    sel.hass = hass
+
+    assert sel.options == ["Ground", "Upstairs"]
+    assert sel.current_option == "Ground"
+
+    await sel.async_select_option("Upstairs")
+
+    coord.device.set_current_map.assert_called_once_with(2)
+    coord.async_request_map_upload.assert_awaited_once_with(2)
     coord.async_request_refresh.assert_awaited_once()
 
 

--- a/tests/harness/test_oauth.py
+++ b/tests/harness/test_oauth.py
@@ -18,6 +18,7 @@ from custom_components.xiaomi_vac.const import (
     CONF_OAUTH_EXPIRES_TS,
     CONF_OAUTH_REFRESH_TOKEN,
     CONF_OAUTH_REGION,
+    CONF_OAUTH_REDIRECT_URI,
 )
 
 
@@ -49,9 +50,13 @@ class _Session:
 def test_build_authorize_url_uses_xiaomi_state() -> None:
     """The authorize URL matches Xiaomi's MIoT OAuth contract."""
     device_id = "ha.0123456789abcdef"
-    query = parse_qs(urlparse(build_authorize_url(device_id)).query)
+    redirect_uri = "http://homeassistant.local:8123/api/webhook/test"
+    query = parse_qs(
+        urlparse(build_authorize_url(device_id, redirect_uri=redirect_uri)).query
+    )
 
     assert query["client_id"] == [OAUTH_APP_ID]
+    assert query["redirect_uri"] == [redirect_uri]
     assert query["response_type"] == ["code"]
     assert query["device_id"] == [device_id]
     assert query["skip_confirm"] == ["true"]
@@ -70,12 +75,18 @@ def test_exchange_code_parses_tokens_and_early_expiry() -> None:
     session = _Session()
 
     tokens = exchange_code(
-        "ALSG_code", "ha.0123456789abcdef", "sg", session=session, now=100
+        "ALSG_code",
+        "ha.0123456789abcdef",
+        "sg",
+        redirect_uri="http://ha.local/callback",
+        session=session,
+        now=100,
     )
 
     assert session.url == "https://sg.ha.api.io.mi.com/app/v2/ha/oauth/get_token"
     payload = json.loads(session.params["data"])
     assert payload["code"] == "ALSG_code"
+    assert payload["redirect_uri"] == "http://ha.local/callback"
     assert payload["device_id"] == "ha.0123456789abcdef"
     assert tokens.access_token == "access"
     assert tokens.refresh_token == "refresh2"
@@ -134,6 +145,7 @@ def test_refreshed_oauth_entry_updates_force_refresh() -> None:
             CONF_OAUTH_REFRESH_TOKEN: "refresh1",
             CONF_OAUTH_REGION: "sg",
             CONF_OAUTH_DEVICE_ID: "ha.0123456789abcdef",
+            CONF_OAUTH_REDIRECT_URI: "http://ha.local/callback",
             CONF_OAUTH_EXPIRES_TS: 9999,
         },
         force=True,
@@ -143,10 +155,12 @@ def test_refreshed_oauth_entry_updates_force_refresh() -> None:
 
     payload = json.loads(session.params["data"])
     assert payload["refresh_token"] == "refresh1"
+    assert payload["redirect_uri"] == "http://ha.local/callback"
     assert updates == {
         CONF_OAUTH_ACCESS_TOKEN: "access",
         CONF_OAUTH_REFRESH_TOKEN: "refresh2",
         CONF_OAUTH_EXPIRES_TS: 800,
         CONF_OAUTH_REGION: "sg",
         CONF_OAUTH_DEVICE_ID: "ha.0123456789abcdef",
+        CONF_OAUTH_REDIRECT_URI: "http://ha.local/callback",
     }

--- a/tests/harness/test_setup_entry.py
+++ b/tests/harness/test_setup_entry.py
@@ -10,9 +10,15 @@ from homeassistant.helpers.update_coordinator import UpdateFailed
 from pytest_homeassistant_custom_component.common import MockConfigEntry
 
 from custom_components.xiaomi_vac import PLATFORMS, async_setup_entry
+from custom_components.xiaomi_vac import _async_start_mqtt
 from custom_components.xiaomi_vac.const import (
+    CONF_DEVICE_ID,
     CONF_HOST,
     CONF_MODEL,
+    CONF_OAUTH_ACCESS_TOKEN,
+    CONF_OAUTH_DEVICE_ID,
+    CONF_OAUTH_REGION,
+    CONF_OAUTH_REFRESH_TOKEN,
     CONF_SERVICE_TOKEN,
     CONF_TOKEN,
     DOMAIN,
@@ -186,3 +192,82 @@ async def test_setup_entry_without_oauth_has_no_mqtt_client(hass: HomeAssistant)
 
     assert result is True
     assert entry.runtime_data.mqtt is None
+
+
+async def test_setup_entry_refreshes_oauth_before_mqtt_start(
+    hass: HomeAssistant,
+) -> None:
+    """Stored OAuth is refreshed proactively before MQTT is constructed."""
+    data = {
+        **_BASE_DATA,
+        CONF_DEVICE_ID: "did123",
+        CONF_OAUTH_ACCESS_TOKEN: "old",
+        CONF_OAUTH_REFRESH_TOKEN: "refresh",
+        CONF_OAUTH_REGION: "sg",
+        CONF_OAUTH_DEVICE_ID: "ha.abc",
+    }
+    entry = _entry("AA:BB:CC:DD:EE:05", data)
+    entry.add_to_hass(hass)
+
+    fake_device = _fake_device()
+    mqtt_instance = MagicMock()
+    mqtt_instance.async_start = AsyncMock()
+
+    with (
+        patch("custom_components.xiaomi_vac.IjaiVacuumDevice", return_value=fake_device),
+        patch(
+            "custom_components.xiaomi_vac.coordinator.XiaomiVacuumCoordinator"
+            ".async_config_entry_first_refresh",
+            new=AsyncMock(),
+        ),
+        patch(
+            "custom_components.xiaomi_vac.async_refresh_oauth_entry",
+            new=AsyncMock(return_value=False),
+        ) as refresh,
+        patch("custom_components.xiaomi_vac.MiotMqttClient", return_value=mqtt_instance),
+        patch.object(
+            hass.config_entries,
+            "async_forward_entry_setups",
+            new=AsyncMock(return_value=True),
+        ),
+    ):
+        result = await async_setup_entry(hass, entry)
+
+    assert result is True
+    refresh.assert_awaited_once_with(hass, entry, force=False)
+    mqtt_instance.async_start.assert_awaited_once()
+
+
+async def test_mqtt_token_provider_refreshes_before_returning_token(
+    hass: HomeAssistant,
+) -> None:
+    """The MQTT token provider does a due-check refresh even when not forced."""
+    data = {
+        **_BASE_DATA,
+        CONF_DEVICE_ID: "did123",
+        CONF_OAUTH_ACCESS_TOKEN: "old",
+        CONF_OAUTH_REFRESH_TOKEN: "refresh",
+        CONF_OAUTH_REGION: "sg",
+        CONF_OAUTH_DEVICE_ID: "ha.abc",
+    }
+    entry = _entry("AA:BB:CC:DD:EE:06", data)
+    entry.add_to_hass(hass)
+    mqtt_instance = MagicMock()
+    mqtt_instance.async_start = AsyncMock()
+
+    with (
+        patch(
+            "custom_components.xiaomi_vac.async_refresh_oauth_entry",
+            new=AsyncMock(return_value=False),
+        ) as refresh,
+        patch("custom_components.xiaomi_vac.MiotMqttClient", return_value=mqtt_instance) as cls,
+    ):
+        await _async_start_mqtt(hass, entry, None, MagicMock())
+
+        provider = cls.call_args.kwargs["token_provider"]
+        refresh.reset_mock()
+
+        token = await provider(False)
+
+    assert token == "old"
+    refresh.assert_awaited_once_with(hass, entry, force=False)

--- a/tests/pure/conftest.py
+++ b/tests/pure/conftest.py
@@ -19,6 +19,13 @@ _PKG = os.path.join(
 if _PKG not in sys.path:
     sys.path.insert(0, _PKG)
 
+# Synthetic package so modules with relative imports (map.py) can load without
+# executing the HA-importing package __init__. Import as `xvac.map`.
+if "xvac" not in sys.modules:
+    _xvac = ModuleType("xvac")
+    _xvac.__path__ = [_PKG]
+    sys.modules["xvac"] = _xvac
+
 _TOOLS = os.path.join(_ROOT, ".tools")
 tools_pkg = ModuleType("tools")
 tools_pkg.__path__ = [_TOOLS]

--- a/tests/pure/test_device_control.py
+++ b/tests/pure/test_device_control.py
@@ -94,6 +94,37 @@ def test_clean_segments_uses_v17_room_clean_action(monkeypatch):
     assert _last_calls() == [("action", 2, 7, ["10,12"])]
 
 
+def test_clean_segments_uses_v3_room_clean_action(monkeypatch):
+    device_mod = load_device_module(monkeypatch)
+    device = device_mod.IjaiVacuumDevice("host", "token", "ijai.vacuum.v3")
+
+    device.clean_segments([10, 12])
+
+    assert _last_calls() == [("action", 2, 7, ["10,12"])]
+
+
+def test_request_map_upload_prefers_upload_by_mapid_ii(monkeypatch):
+    device_mod = load_device_module(monkeypatch)
+    device = device_mod.IjaiVacuumDevice("host", "token", "ijai.vacuum.v3")
+
+    device.request_map_upload(7)
+
+    assert _last_calls() == [("action", 10, 14, [7])]
+
+
+def test_request_map_upload_falls_back_to_upload_by_mapid(monkeypatch):
+    device_mod = load_device_module(monkeypatch)
+    device = device_mod.IjaiVacuumDevice("host", "token", "ijai.vacuum.v3")
+    FakeMiotDevice.action_results[(10, 14)] = RuntimeError("-1")
+
+    device.request_map_upload(7)
+
+    assert _last_calls() == [
+        ("action", 10, 14, [7]),
+        ("action", 10, 2, [7]),
+    ]
+
+
 def test_map_list_parses_map_list_output(monkeypatch):
     device_mod = load_device_module(monkeypatch)
     device = device_mod.IjaiVacuumDevice("host", "token", "ijai.vacuum.v17")

--- a/tests/pure/test_dreame_map.py
+++ b/tests/pure/test_dreame_map.py
@@ -1,0 +1,207 @@
+"""Phase 3 synthetic Dreame map tests: mechanics only, no real blob.
+
+Covers parser construction per model, the three decrypt paths (parser-IV,
+zero-IV, plain), fetch() failure fallbacks, enckey extraction edges, and
+the enckey re-poll after a decrypt failure. See dreame-map.md.
+"""
+from __future__ import annotations
+
+import base64
+import hashlib
+import zlib
+from types import SimpleNamespace
+
+import pytest
+
+import map_parsers
+from spec.registry import MODEL_PROFILES
+
+# Loaded via the synthetic `xvac` package (see conftest) — map.py has relative
+# imports so it can't be imported standalone.
+from xvac.map import MapFetcher, SessionExpired
+
+
+def _dreame_models():
+    return sorted(
+        m for m, p in MODEL_PROFILES.items()
+        if p.brand == "dreame" and p.map is not None
+    )
+
+
+# --- parser construction for every registered dreame model ---------------
+@pytest.mark.parametrize("model", _dreame_models())
+def test_dreame_parser_constructs(model):
+    from vacuum_map_parser_base.config.color import ColorsPalette
+    from vacuum_map_parser_base.config.image_config import ImageConfig
+    from vacuum_map_parser_base.config.size import Sizes
+
+    parser = map_parsers.make_parser(
+        "dreame", model, ColorsPalette(), Sizes(), [], ImageConfig(), [])
+    assert type(parser).__name__ == "DreameMapDataParser"
+
+
+# --- enckey extraction edges ----------------------------------------------
+def test_dreame_extract_enckey_edges():
+    f = map_parsers.dreame_extract_enckey
+    assert f("no_comma") is None          # no comma
+    assert f("") is None                  # empty value
+    assert f("path,KEY") == "KEY"         # one comma
+    assert f("path,KEY,extra") == "KEY"   # extra comma data: key is parts[1]
+    assert f("path,") is None             # empty key
+
+
+# --- MapFetcher helpers ----------------------------------------------------
+class FakeCloud:
+    """Duck-typed XiaomiCloud: canned enckey prop, URL and blob."""
+
+    def __init__(self, *, prop_value=None, url="http://x", blob=b""):
+        self.prop_value = prop_value
+        self.url = url
+        self.blob = blob
+        self.prop_calls = 0
+
+    def cloud_get_prop(self, server, did, siid, piid):
+        self.prop_calls += 1
+        assert (siid, piid) == (6, 3)
+        return {"result": [{"value": self.prop_value}]}
+
+    def map_url(self, server, did, slot, endpoint):
+        return self.url
+
+    def download(self, url):
+        return self.blob
+
+
+def _fetcher(cloud, model="dreame.vacuum.p2008"):
+    return MapFetcher(
+        cloud, server="de", user_id="1", device_id="2", model=model,
+        mac="AA", wifi_sn="SN", parser_brand="dreame")
+
+
+def _zero_iv_blob(plaintext: bytes, enckey: str) -> bytes:
+    """Encrypt with the Tasshack chain (inverse of dreame_decrypt_cloud_blob)."""
+    from Crypto.Cipher import AES
+    from Crypto.Util.Padding import pad
+
+    key = hashlib.sha256(enckey.encode()).hexdigest()[:32].encode("utf8")
+    enc = AES.new(key, AES.MODE_CBC, iv=b"\x00" * 16).encrypt(pad(zlib.compress(plaintext), 16))
+    return base64.b64encode(enc)
+
+
+class RecorderParser:
+    """Stub parser recording unpack_map calls."""
+
+    def __init__(self):
+        self.calls = []
+
+    def unpack_map(self, raw, **kw):
+        self.calls.append((raw, kw))
+        return b"unpacked"
+
+
+# --- decrypt path selection -----------------------------------------------
+def test_iv_model_delegates_to_parser_unpack(monkeypatch):
+    from vacuum_map_parser_dreame.map_data_parser import DreameMapDataParser
+
+    cloud = FakeCloud()
+    f = _fetcher(cloud, model="dreame.vacuum.ivtest")
+    f._enckey = "KEY"
+    rec = RecorderParser()
+    f._parser = rec
+    monkeypatch.setitem(DreameMapDataParser.IVs, "dreame.vacuum.ivtest", "0102030405060708")
+
+    assert f._unpack(b"raw") == b"unpacked"
+    assert rec.calls == [(b"raw", {"enckey": "KEY"})]
+
+
+def test_non_iv_model_uses_zero_iv_helper():
+    from vacuum_map_parser_dreame.map_data_parser import DreameMapDataParser
+
+    model = "dreame.vacuum.p2008"
+    assert DreameMapDataParser.IVs.get(model) is None  # guard the premise
+
+    cloud = FakeCloud()
+    f = _fetcher(cloud, model=model)
+    f._enckey = "KEY"
+    rec = RecorderParser()
+    f._parser = rec  # must NOT be called
+
+    plaintext = b"synthetic map bytes " * 3
+    assert f._unpack(_zero_iv_blob(plaintext, "KEY")) == plaintext
+    assert rec.calls == []
+
+
+def test_plain_path_no_enckey():
+    """No enckey -> parser.unpack_map with no kwargs (plain zlib models)."""
+    cloud = FakeCloud()
+    f = _fetcher(cloud)
+    assert f._enckey is None
+    rec = RecorderParser()
+    f._parser = rec
+
+    f._unpack(b"raw")
+    assert rec.calls == [(b"raw", {})]
+
+
+# --- fetch() failure paths return None, never raise ------------------------
+def test_fetch_no_url_raises_session_expired():
+    f = _fetcher(FakeCloud(prop_value=None, url=None))
+    with pytest.raises(SessionExpired):
+        f.fetch()
+
+
+def test_fetch_empty_download_returns_none():
+    assert _fetcher(FakeCloud(blob=b"")).fetch() is None
+
+
+@pytest.mark.parametrize("blob", [
+    b"\xff\xfenot base64 or zlib",      # garbage
+    b"AAAA",                             # valid b64, not zlib
+    zlib.compress(b"not a map frame"),   # valid zlib, wrong frame
+])
+def test_fetch_bad_blob_returns_none(blob):
+    assert _fetcher(FakeCloud(prop_value="path/obj", blob=blob)).fetch() is None
+
+
+def test_fetch_empty_map_returns_none():
+    """A parse that yields no image is reported as None, not a crash."""
+    f = _fetcher(FakeCloud(blob=b"x"))
+    f._parser = SimpleNamespace(
+        unpack_map=lambda raw, **kw: b"u",
+        parse=lambda unpacked: SimpleNamespace(image=None),
+    )
+    assert f.fetch() is None
+
+
+def test_parse_failure_keeps_enckey(monkeypatch):
+    """Decrypt OK but parser rejects the frame: key material is good, keep it."""
+    from vacuum_map_parser_dreame.map_data_parser import DreameMapDataParser
+
+    model = "dreame.vacuum.ivtest"
+    monkeypatch.setitem(DreameMapDataParser.IVs, model, "0102030405060708")
+    cloud = FakeCloud(prop_value="path/obj,KEY", blob=b"x")
+    f = _fetcher(cloud, model=model)
+
+    def _bad_parse(unpacked):
+        raise ValueError("bad frame")
+
+    # IV model -> _unpack delegates to the (stub) parser; decrypt "succeeds",
+    # parse fails.
+    f._parser = SimpleNamespace(unpack_map=lambda raw, **kw: b"u", parse=_bad_parse)
+
+    assert f.fetch() is None
+    assert f._enckey == "KEY"           # key kept
+    assert f._enckey_polled is True     # no re-poll scheduled
+    assert cloud.prop_calls == 1        # only the initial poll
+
+
+# --- enckey re-poll after decrypt failure ----------------------------------
+def test_fetch_repolls_enckey_after_decrypt_failure():
+    cloud = FakeCloud(prop_value="path/obj,KEY", blob=b"garbage")
+    f = _fetcher(cloud)
+
+    assert f.fetch() is None            # decrypt fails
+    assert f._enckey is None            # key dropped
+    assert f._enckey_polled is False    # will re-poll
+    assert f.fetch() is None
+    assert cloud.prop_calls == 2        # polled again on the second fetch

--- a/tests/pure/test_generator_goldens.py
+++ b/tests/pure/test_generator_goldens.py
@@ -61,7 +61,9 @@ def test_registry_profiles_are_value_equal_to_generated_drafts() -> None:
 
     for model, profile in MODEL_PROFILES.items():
         assert model in drafts
-        assert replace(profile, profile_id="") == replace(drafts[model], profile_id="")
+        assert replace(profile, profile_id="", notes=()) == replace(
+            drafts[model], profile_id="", notes=()
+        ), model
 
 
 def test_v17_core_keeps_spec_accurate_labels() -> None:

--- a/tests/pure/test_map.py
+++ b/tests/pure/test_map.py
@@ -160,6 +160,18 @@ def test_required_map_key_inputs_for_xiaomi_rebrand():
     assert map_parsers.required_map_key_inputs(key) == {"wifi_sn", "device_mac"}
 
 
+@pytest.mark.parametrize(
+    "model",
+    ["dreame.vacuum.p2009", "dreame.vacuum.p2036", "dreame.vacuum.r2215"],
+)
+def test_dreame_phase1_hub_profiles_route_to_dreame_parser(model):
+    from spec.registry import get_profile
+
+    profile = get_profile(model)
+    assert profile.map is not None
+    assert map_parsers.parser_key(profile) == "dreame"
+
+
 def test_has_ijai_grid_only_ijai():
     assert map_parsers.has_ijai_grid("ijai") is True
     for brand in ("xiaomi", "dreame", "viomi", "roidmi"):

--- a/tests/pure/test_registry.py
+++ b/tests/pure/test_registry.py
@@ -34,6 +34,16 @@ def test_distinct_core_count_matches_promoted_profiles() -> None:
     assert len(cores) == 22
 
 
+def test_registered_profiles_include_spec_notes() -> None:
+    profiles = {id(profile): profile for profile in MODEL_PROFILES.values()}
+    for profile in profiles.values():
+        assert profile.notes
+        assert all(
+            note.startswith("urn:miot-spec-v2:device:vacuum:")
+            for note in profile.notes
+        )
+
+
 @pytest.mark.parametrize(("model", "profile"), sorted(MODEL_PROFILES.items()))
 def test_core_policy_for_registered_models(model: str, profile) -> None:
     if model.startswith("roidmi."):

--- a/tests/pure/test_registry.py
+++ b/tests/pure/test_registry.py
@@ -23,9 +23,9 @@ def test_registry_counts_match_card_baseline() -> None:
     supported = [model for model in MODEL_PROFILES if is_supported(model)]
     rejected = [model for model in MODEL_PROFILES if not is_supported(model)]
 
-    assert len(MODEL_PROFILES) == 85
+    assert len(MODEL_PROFILES) == 88
     assert len(supported) == 67
-    assert len(rejected) == 18
+    assert len(rejected) == 21
 
 
 def test_distinct_core_count_matches_promoted_profiles() -> None:


### PR DESCRIPTION
Rolls up the map-fixes work for the 1.2.1 release. Fixes the main complaints from #4 (and should cover the OAuth bugs re-reported in #7).

## What changed

- **Map reliability**: local cache, two-slot cloud fetch, graceful fallback when a slot holds an undecryptable blob. Maps no longer need the Mi Home app open — MQTT map events now trigger an upload request directly.
- **OAuth**: reworked into a webhook flow. The authorization link shows during setup again (v1.2.0 regression) and the redirect code is picked up automatically; manual paste still works.
- **Room clean on ijai.vacuum.v3**: retries through the Xiaomi cloud when the local command times out ("user ack timeout").
- **wifi_sn**: falls back to the stored value when the live read fails, instead of killing the map.
- **Sign-in errors**: Xiaomi's actual rejection reason (e.g. 登录验证失败 account verification) is surfaced instead of a generic failure.
- **Dreame**: p2041 family promoted from the spec sweep; map path hardened (a parse failure no longer discards a good enckey) and covered by synthetic tests. Still best-effort until someone with real hardware sends evidence.
- Boot-time map upload throttle fix, version bump to 1.2.1.

## Testing

Full pure + harness suites green (141 tests). Map/OAuth/MQTT behaviour verified live on ijai.vacuum.v17. The dreame changes are synthetic-only — no real blob exists to test against yet.