### PR TITLE
V17 room clean

### DIFF
--- a/SUPPORTED-MODELS.md
+++ b/SUPPORTED-MODELS.md
@@ -4,7 +4,7 @@ This list is generated from the integration code, using models where
 `custom_components/xiaomi_vac/spec/registry.py:is_supported(model)` returns
 `True`.
 
-Total supported models: 67
+Total supported models: 73
 
 ## Dreame
 
@@ -81,6 +81,12 @@ Total supported models: 67
 - `xiaomi.vacuum.c101eu`
 - `xiaomi.vacuum.c103`
 - `xiaomi.vacuum.c104`
+- `xiaomi.vacuum.c107`
+- `xiaomi.vacuum.d101`
+- `xiaomi.vacuum.d102ev`
+- `xiaomi.vacuum.d102gl`
 - `xiaomi.vacuum.d106gl`
+- `xiaomi.vacuum.d109gl`
 - `xiaomi.vacuum.ov21gl`
+- `xiaomi.vacuum.ov43gb`
 - `xiaomi.vacuum.ov71gl`

--- a/custom_components/xiaomi_vac/device.py
+++ b/custom_components/xiaomi_vac/device.py
@@ -17,8 +17,15 @@ class DeviceCommunicationError(Exception):
     """Raised when a required device property cannot be read."""
 
 
-# Lengths the firmware uses for the wifi serial that seeds the map AES key.
-_WIFI_SN_LENS = (18, 20)
+# Length range for the wifi serial that seeds the map AES key. Firmware isn't
+# consistent here — v3 reports 19, the old code only allowed 18 or 20 — so this
+# is a range rather than a whitelist (issue #4).
+_WIFI_SN_MIN_LEN = 16
+_WIFI_SN_MAX_LEN = 24
+
+
+def _is_wifi_sn(value: str) -> bool:
+    return _WIFI_SN_MIN_LEN <= len(value) <= _WIFI_SN_MAX_LEN and value.isupper()
 
 
 @dataclass
@@ -319,7 +326,7 @@ class IjaiVacuumDevice:
             except Exception as err:  # noqa: BLE001
                 _LOGGER.debug("wifi_sn: siid 1/piid %s read failed: %s", piid, err)
                 continue
-            if isinstance(val, str) and len(val) in _WIFI_SN_LENS and val.isupper():
+            if isinstance(val, str) and _is_wifi_sn(val):
                 return val
             _LOGGER.debug("wifi_sn: siid 1/piid %s value %r did not match expected shape", piid, val)
         try:
@@ -330,7 +337,7 @@ class IjaiVacuumDevice:
         for part in str(raw).split(","):
             # The serial sits before an optional ";<uid>" suffix on siid 7/piid 45.
             p = part.replace('"', "").split(";")[0]
-            if len(p) in _WIFI_SN_LENS and p.isalnum() and p.isupper():
+            if _is_wifi_sn(p) and p.isalnum():
                 return p
         _LOGGER.debug("wifi_sn: siid 7/piid 45 value %r had no matching serial part", raw)
         return None

--- a/custom_components/xiaomi_vac/manifest.json
+++ b/custom_components/xiaomi_vac/manifest.json
@@ -20,5 +20,5 @@
     "Pillow==12.2.0",
     "paho-mqtt==2.1.0"
   ],
-  "version": "1.2.2"
+  "version": "1.2.3"
 }

--- a/custom_components/xiaomi_vac/spec/profiles/xiaomi.py
+++ b/custom_components/xiaomi_vac/spec/profiles/xiaomi.py
@@ -899,3 +899,62 @@ XIAOMI_OV71GL = replace(
     profile_id='xiaomi.ov71gl',
     notes=("urn:miot-spec-v2:device:vacuum:0000A006:xiaomi-ov71gl:1",),
 )
+
+# xiaomi.vacuum.ov43gb — identical spec layout to ov21gl
+XIAOMI_OV43GB = replace(
+    XIAOMI_OV21GL,
+    profile_id='xiaomi.ov43gb',
+    notes=("urn:miot-spec-v2:device:vacuum:0000A006:xiaomi-ov43gb:2",),
+)
+
+# c107/d101/d102ev/d102gl/d109gl: same siid/piid layout as ov21gl, but their
+# sweep-type value list stops at 7. status_map keeps the full ov21gl table —
+# codes 22-24 are simply never reported by the shorter-spec models.
+XIAOMI_CORE_C107 = replace(
+    XIAOMI_CORE_OV21GL,
+    sweep_types={
+        'global': 1,
+        'zone': 2,
+        'area': 3,
+        'edge': 4,
+        'costum': 5,
+        'point': 6,
+        'custom_area': 7,
+    },
+)
+
+# xiaomi.vacuum.c107
+XIAOMI_C107 = replace(
+    XIAOMI_OV21GL,
+    profile_id='xiaomi.c107',
+    notes=("urn:miot-spec-v2:device:vacuum:0000A006:xiaomi-c107:2",),
+    core=XIAOMI_CORE_C107,
+)
+
+# xiaomi.vacuum.d101 — identical spec layout to c107
+XIAOMI_D101 = replace(
+    XIAOMI_C107,
+    profile_id='xiaomi.d101',
+    notes=("urn:miot-spec-v2:device:vacuum:0000A006:xiaomi-d101:3",),
+)
+
+# xiaomi.vacuum.d102ev — identical spec layout to c107
+XIAOMI_D102EV = replace(
+    XIAOMI_C107,
+    profile_id='xiaomi.d102ev',
+    notes=("urn:miot-spec-v2:device:vacuum:0000A006:xiaomi-d102ev:1",),
+)
+
+# xiaomi.vacuum.d102gl — identical spec layout to c107
+XIAOMI_D102GL = replace(
+    XIAOMI_C107,
+    profile_id='xiaomi.d102gl',
+    notes=("urn:miot-spec-v2:device:vacuum:0000A006:xiaomi-d102gl:1",),
+)
+
+# xiaomi.vacuum.d109gl — identical spec layout to c107
+XIAOMI_D109GL = replace(
+    XIAOMI_C107,
+    profile_id='xiaomi.d109gl',
+    notes=("urn:miot-spec-v2:device:vacuum:0000A006:xiaomi-d109gl:2",),
+)

--- a/custom_components/xiaomi_vac/spec/registry.py
+++ b/custom_components/xiaomi_vac/spec/registry.py
@@ -46,8 +46,14 @@ from .profiles.xiaomi import (
     XIAOMI_C101EU,
     XIAOMI_C102CN,
     XIAOMI_C104,
+    XIAOMI_C107,
+    XIAOMI_D101,
+    XIAOMI_D102EV,
+    XIAOMI_D102GL,
+    XIAOMI_D109GL,
     XIAOMI_D110CH,
     XIAOMI_OV21GL,
+    XIAOMI_OV43GB,
     XIAOMI_OV71GL,
 )
 from .types import ModelProfile
@@ -79,10 +85,16 @@ MODEL_PROFILES: dict[str, ModelProfile] = {
     "xiaomi.vacuum.c102gl": XIAOMI_C102CN,  # Alias: spec-verified same layout as xiaomi.vacuum.c102cn.
     "xiaomi.vacuum.c103": XIAOMI_C101,  # Alias: spec-verified same layout as xiaomi.vacuum.c101.
     "xiaomi.vacuum.c104": XIAOMI_C104,
+    "xiaomi.vacuum.c107": XIAOMI_C107,
+    "xiaomi.vacuum.d101": XIAOMI_D101,
+    "xiaomi.vacuum.d102ev": XIAOMI_D102EV,
+    "xiaomi.vacuum.d102gl": XIAOMI_D102GL,
     "xiaomi.vacuum.d103cn": XIAOMI_C102CN,  # Alias: spec-verified same layout as xiaomi.vacuum.c102cn.
     "xiaomi.vacuum.d106gl": XIAOMI_C101EU,  # Alias: spec-verified same layout as xiaomi.vacuum.c101eu.
+    "xiaomi.vacuum.d109gl": XIAOMI_D109GL,
     "xiaomi.vacuum.d110ch": XIAOMI_D110CH,
     "xiaomi.vacuum.ov21gl": XIAOMI_OV21GL,
+    "xiaomi.vacuum.ov43gb": XIAOMI_OV43GB,
     "xiaomi.vacuum.ov71gl": XIAOMI_OV71GL,
     # --- viomi --------------------------------------------------------------
     "viomi.vacuum.v12": VIOMI_V12,

--- a/custom_components/xiaomi_vac/www/xiaomi-vac-card.js
+++ b/custom_components/xiaomi_vac/www/xiaomi-vac-card.js
@@ -40,9 +40,9 @@ const modelShort = (m) => {
 };
 // shape 1 is the default fallback for unmapped models
 const MODEL_SHAPE = Object.fromEntries([
-  [1, ["dreame.mb1808","dreame.mc1808","xiaomi.vacuum.ov21gl","dreame.md1808","dreame.p2008","dreame.p2140a","dreame.p2140o","dreame.p2140p","ijai.v10","ijai.v14"]],
+  [1, ["dreame.mb1808","dreame.mc1808","xiaomi.ov21gl","xiaomi.ov43gb","dreame.md1808","dreame.p2008","dreame.p2140a","dreame.p2140o","dreame.p2140p","ijai.v10","ijai.v14"]],
   [2, ["dreame.p2029","dreame.p2028","dreame.p2028a","dreame.p2150b","dreame.p2150o"]],
-  [3, ["ijai.v2","ijai.v3","vacuum.c104","rockrobo.v1","xiaomi.d110ch","xiaomi.d103cn","xiaomi.d102gl","xiaomi.d102ev","xiaomi.d101","xiaomi.c107","xiaomi.c102gl","xiaomi.c102cn","xiaomi.c101eu","xiaomi.c101","dreame.p2114a","dreame.p2114o","dreame.r2210","dreame.r2209","dreame.r2211o","dreame.r2228","dreame.r228o","dreame.r2228o","dreame.r2228z","dreame.r2232a","dreame.r2233","dreame.r2246","dreame.r2247","dreame.r2254","dreame.s5"]],
+  [3, ["ijai.v2","ijai.v3","xiaomi.c104","rockrobo.v1","xiaomi.d110ch","xiaomi.d103cn","xiaomi.d102gl","xiaomi.d102ev","xiaomi.d101","xiaomi.c107","xiaomi.c102gl","xiaomi.c102cn","xiaomi.c101eu","xiaomi.c101","dreame.p2114a","dreame.p2114o","dreame.r2210","dreame.r2209","dreame.r2211o","dreame.r2228","dreame.r2228o","dreame.r2228z","dreame.r2232a","dreame.r2233","dreame.r2246","dreame.r2247","dreame.r2254","dreame.s5"]],
   [4, ["ijai.v17","ijai.v18","ijai.v19","xiaomi.b106eu"]],
   [5, ["dreame.p2041","dreame.p2041o"]],
   [6, ["dreame.p2009","dreame.p2036"]],
@@ -50,7 +50,7 @@ const MODEL_SHAPE = Object.fromEntries([
   [8, ["ijai.v13","ijai.v1","viomi.v24"]],
   [9, ["dreame.p1248o"]],
   [10, ["xiaomi.d106gl","xiaomi.c103","xiaomi.b108gl"]],
-  [11, ["viomi.v12","xiaomi.vacuum.ov71gl","viomi.v13","xiaomi.b106bk","xiaomi.d109gl","dreame.r2215","dreame.r2216o","dreame.r2235"]],
+  [11, ["viomi.v12","xiaomi.ov71gl","viomi.v13","xiaomi.b106bk","xiaomi.d109gl","dreame.r2215","dreame.r2216o","dreame.r2235"]],
   [12, ["xiaomi.b112","xiaomi.b112gl","xiaomi.c108","viomi.v45"]],
   [13, ["xiaomi.b112bk"]],
   [14, ["viomi.v19"]],

--- a/tests/pure/test_card_shapes.py
+++ b/tests/pure/test_card_shapes.py
@@ -1,0 +1,88 @@
+"""Pure tests for the bundled card's MODEL_SHAPE table.
+
+The card looks up `MODEL_SHAPE[modelShort(model)]` and silently falls back to
+shape 1 on a miss, so a malformed key is invisible at runtime.
+"""
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+import pytest
+
+from spec.registry import MODEL_PROFILES, is_supported
+
+_ROOT = Path(__file__).resolve().parents[2]
+_WWW = _ROOT / "custom_components" / "xiaomi_vac" / "www"
+_CARD = _WWW / "xiaomi-vac-card.js"
+_LOTTIE = _WWW / "lottie"
+
+_STATES = ("charging", "paused", "returning", "vacuuming")
+
+# Supported models with no MODEL_SHAPE entry: they render shape 1 (the wrong
+# robot, no error). Shrink this list, never grow it.
+_KNOWN_MISSING_SHAPE = {
+    "dreame.vacuum.p2027",
+    "dreame.vacuum.p2140",
+    "dreame.vacuum.p2148o",
+    "dreame.vacuum.p2149o",
+    "dreame.vacuum.p2150a",
+    "dreame.vacuum.p2187",
+    "dreame.vacuum.r2104",
+    "dreame.vacuum.r2205",
+    "ijai.vacuum.v15",
+    "viomi.vacuum.v18",
+}
+
+
+def _model_short(model: str) -> str:
+    """Mirror of modelShort() in xiaomi-vac-card.js."""
+    parts = model.split(".")
+    if len(parts) >= 3 and parts[1] == "vacuum":
+        return parts[0] + "." + ".".join(parts[2:])
+    return model
+
+
+def _shape_pairs() -> list[tuple[str, int]]:
+    src = _CARD.read_text(encoding="utf-8")
+    mo = re.search(r"const MODEL_SHAPE = Object\.fromEntries\(\[(.*?)\]\.flatMap", src, re.S)
+    assert mo, "MODEL_SHAPE table not found in xiaomi-vac-card.js"
+
+    pairs: list[tuple[str, int]] = []
+    for shape, ids in re.findall(r"\[(\d+),\s*\[(.*?)\]\]", mo.group(1), re.S):
+        pairs.extend((model_id, int(shape)) for model_id in re.findall(r'"([^"]+)"', ids))
+    assert pairs, "MODEL_SHAPE parsed as empty"
+    return pairs
+
+
+def test_shape_keys_are_short_form() -> None:
+    """A key containing '.vacuum.' can never match modelShort() output."""
+    long_form = sorted(key for key, _shape in _shape_pairs() if ".vacuum." in key)
+
+    assert not long_form
+
+
+def test_shape_keys_are_unique() -> None:
+    keys = [key for key, _shape in _shape_pairs()]
+    duplicates = sorted({key for key in keys if keys.count(key) > 1})
+
+    assert not duplicates
+
+
+@pytest.mark.parametrize("state", _STATES)
+def test_every_shape_has_its_lottie_assets(state: str) -> None:
+    shapes = {shape for _key, shape in _shape_pairs()}
+    missing = sorted(shape for shape in shapes if not (_LOTTIE / f"shape-{shape}-{state}.json").is_file())
+
+    assert not missing
+
+
+def test_supported_models_have_a_card_shape() -> None:
+    keys = {key for key, _shape in _shape_pairs()}
+    missing = {
+        model
+        for model in MODEL_PROFILES
+        if is_supported(model) and _model_short(model) not in keys
+    }
+
+    assert missing == _KNOWN_MISSING_SHAPE

--- a/tests/pure/test_registry.py
+++ b/tests/pure/test_registry.py
@@ -23,15 +23,15 @@ def test_registry_counts_match_card_baseline() -> None:
     supported = [model for model in MODEL_PROFILES if is_supported(model)]
     rejected = [model for model in MODEL_PROFILES if not is_supported(model)]
 
-    assert len(MODEL_PROFILES) == 88
-    assert len(supported) == 67
+    assert len(MODEL_PROFILES) == 94
+    assert len(supported) == 73
     assert len(rejected) == 21
 
 
 def test_distinct_core_count_matches_promoted_profiles() -> None:
     cores = {repr(profile.core) for profile in MODEL_PROFILES.values() if profile.core}
 
-    assert len(cores) == 22
+    assert len(cores) == 23
 
 
 def test_registered_profiles_include_spec_notes() -> None:


### PR DESCRIPTION
Fixed the "Missing map key input wifi_sn" error that was taking the map down on ijai.vacuum.v3. The vacuum was reporting its serial correctly the whole time, we were throwing it away: the code only accepted serials of exactly 18 or 20 characters, and the v3 reports 19. It now accepts a range, so the map decrypts instead of failing on a serial that was right there.