### PR TITLE
Add xiaomi.vacuum.ov42gl (H50 Pro) support, with a working map camera

### DIFF
--- a/SUPPORTED-MODELS.md
+++ b/SUPPORTED-MODELS.md
@@ -88,5 +88,6 @@ Total supported models: 73
 - `xiaomi.vacuum.d106gl`
 - `xiaomi.vacuum.d109gl`
 - `xiaomi.vacuum.ov21gl`
+- `xiaomi.vacuum.ov42gl`
 - `xiaomi.vacuum.ov43gb`
 - `xiaomi.vacuum.ov71gl`

--- a/custom_components/xiaomi_vac/cloud/connector.py
+++ b/custom_components/xiaomi_vac/cloud/connector.py
@@ -422,25 +422,36 @@ class XiaomiCloud:
 
     def map_url(self, server: str, did: str, map_name: str = "0",
                 endpoint: str = "get_interim_file_url_pro") -> str | None:
+        """Mint a signed download URL for one map object.
+
+        Tries the alternate endpoint (get_interim_file_url vs. _pro) on ANY
+        failure, not just code -8 — some brands (observed live: 3irobotic-
+        manufactured xiaomi.* models like ov42gl) reject the "wrong" endpoint
+        for their account with other codes too (e.g. -6 "invalid config for
+        fds"), and there's no complete list of which codes mean "wrong
+        endpoint" vs. an actual dead object/session. Always trying both is
+        more robust than chasing individual error codes.
+        """
         obj = f"{self.user_id}/{did}/{map_name}"
+        resp = self._try_map_url(server, obj, endpoint)
+        if resp is not None:
+            return resp
+
+        alt = ("get_interim_file_url" if endpoint == "get_interim_file_url_pro"
+               else "get_interim_file_url_pro")
+        alt_resp = self._try_map_url(server, obj, alt)
+        if alt_resp is not None:
+            _LOGGER.debug("map_url: %s failed, succeeded with %s", endpoint, alt)
+            return alt_resp
+        return None
+
+    def _try_map_url(self, server: str, obj_name: str, endpoint: str) -> str | None:
         resp = self._call(self._api_url(server) + f"/v2/home/{endpoint}",
-                          {"data": f'{{"obj_name":"{obj}"}}'})
+                          {"data": f'{{"obj_name":"{obj_name}"}}'})
         try:
             return resp["result"]["url"]
         except (TypeError, KeyError):
-            pass
-        if isinstance(resp, dict) and resp.get("code") == -8:
-            alt = ("get_interim_file_url" if endpoint == "get_interim_file_url_pro"
-                   else "get_interim_file_url_pro")
-            resp2 = self._call(self._api_url(server) + f"/v2/home/{alt}",
-                               {"data": f'{{"obj_name":"{obj}"}}'})
-            try:
-                url = resp2["result"]["url"]
-                _LOGGER.debug("map_url: %s rejected (code -8), succeeded with %s", endpoint, alt)
-                return url
-            except (TypeError, KeyError):
-                pass
-        return None
+            return None
 
     def download(self, url: str) -> bytes | None:
         r = self._s.get(url, timeout=15)

--- a/custom_components/xiaomi_vac/map.py
+++ b/custom_components/xiaomi_vac/map.py
@@ -159,6 +159,11 @@ class MapFetcher:
         dreame with enckey: if the parser has a model-specific IV, delegate to
         parser.unpack_map (it applies AES-CBC with that IV). Otherwise use the
         Tasshack zero-IV chain via dreame_decrypt_cloud_blob.
+        xiaomi: bypasses parser.unpack_map (vacuum_map_parser_xiaomi's own
+        decrypt() is broken for this whole model family, see
+        xiaomi_json_decrypt.py) and decrypts locally instead. Returns a JSON
+        *string*, not bytes, same contract as the upstream decrypt() this
+        replaces (parser.parse() only accepts str or dict).
         All other paths go through parser.unpack_map normally.
         """
         if self._brand == "dreame" and self._enckey is not None:
@@ -166,6 +171,9 @@ class MapFetcher:
             if DreameMapDataParser.IVs.get(self._model) is not None:
                 return self._parser.unpack_map(raw, enckey=self._enckey)
             return dreame_decrypt_cloud_blob(raw, self._enckey)
+        if self._brand == "xiaomi":
+            from .xiaomi_json_decrypt import decrypt_xiaomi_json_map
+            return decrypt_xiaomi_json_map(raw, self._model, self._device_id)
         return self._parser.unpack_map(raw, **self._unpack_kw)
 
     def fetch(self, slot: str = "0") -> MapResult | None:
@@ -249,5 +257,8 @@ class MapFetcher:
             attributes=attributes,
             vector=vector,
             map_id=vector.get("map_id"),
-            content_hash=hashlib.sha256(unpacked).hexdigest(),
+            # xiaomi's _unpack returns a str (JSON text), every other brand bytes.
+            content_hash=hashlib.sha256(
+                unpacked.encode("utf-8") if isinstance(unpacked, str) else unpacked
+            ).hexdigest(),
         )

--- a/custom_components/xiaomi_vac/map_coordinator.py
+++ b/custom_components/xiaomi_vac/map_coordinator.py
@@ -367,10 +367,26 @@ class XiaomiMapCoordinator(DataUpdateCoordinator[MapResult]):
     def _fetch_slots(self) -> list[MapResult | None]:
         """Blocking: try every cloud slot for the active map this cycle.
 
-        A raised SessionExpired from an earlier slot short-circuits the rest —
-        the whole session is dead, not just this slot's blob.
+        Each slot's SessionExpired is caught independently instead of
+        short-circuiting the rest of the list: the object backing one slot
+        (e.g. Map Obj Name) can be permanently unavailable server-side while
+        a different object for the same device (e.g. Trajectory Obj Name)
+        still resolves fine — that's not a dead session, just a dead object.
+        SessionExpired is only re-raised when EVERY slot came back with no
+        URL, since that's the actual "whole session is dead" signal the
+        coordinator's refresh/reauth handling wants.
         """
-        return [self._fetcher.fetch(slot) for slot in _SLOTS]
+        results: list[MapResult | None] = []
+        any_resolved = False
+        for slot in _SLOTS:
+            try:
+                results.append(self._fetcher.fetch(slot))
+                any_resolved = True
+            except SessionExpired:
+                results.append(None)
+        if not any_resolved:
+            raise SessionExpired()
+        return results
 
     def _resolve_active_id(
         self, active_meta: dict | None, decoded: list[MapResult], maps_meta: list[dict],
@@ -461,7 +477,20 @@ class XiaomiMapCoordinator(DataUpdateCoordinator[MapResult]):
                 # re-auth (raises a reauth flow) rather than dead-end.
                 if not await self._refresh_and_persist():
                     raise ConfigEntryAuthFailed("Xiaomi cloud map session expired") from None
-                slot_results = await self.hass.async_add_executor_job(self._fetch_slots)
+                try:
+                    slot_results = await self.hass.async_add_executor_job(self._fetch_slots)
+                except SessionExpired:
+                    # The passToken renewal just above proved the account
+                    # credentials are valid, so a second empty map URL right
+                    # after isn't an auth problem — the cloud simply has
+                    # nothing to serve yet (no map uploaded under this
+                    # obj_name, region mismatch, transient hiccup). Reporting
+                    # this as ConfigEntryAuthFailed would force a reauth the
+                    # user can never satisfy (login keeps succeeding, then
+                    # immediately bounces back to reauth every cycle).
+                    raise UpdateFailed(
+                        "Xiaomi cloud has no map available (session is valid)"
+                    ) from None
 
             decoded = [r for r in slot_results if r is not None]
             active_meta = next((m for m in maps_meta if m.get("cur")), None)

--- a/custom_components/xiaomi_vac/map_parsers.py
+++ b/custom_components/xiaomi_vac/map_parsers.py
@@ -57,10 +57,25 @@ def dreame_decrypt_cloud_blob(raw: bytes, enckey: str) -> bytes:
 # parser READMEs; assumed xiaomi-JSON by family resemblance — route to ijai
 # only if hardware testing contradicts this. Every other xiaomi.* profile is
 # an ijai-engine rebrand (RobotMap protobuf: c103/c104/b106eu etc.).
+#
+# ov42gl/ov43gb (2026-07-31): same reasoning as ov21gl — same siid=2 core
+# layout AND (ov42gl only, hardware-confirmed) the same siid=10 vacuum-map
+# service (Map Obj Name/Trajectory Obj Name/Map Management/Room Information),
+# so they belong to the same map family. Routing them through the *ijai*
+# parser/endpoint instead (the pre-fix behaviour: any xiaomi.* profile not in
+# this set falls back to "ijai") is the leading suspect for the live
+# "-6 invalid config for fds" cloud error on ov42gl: it picks the wrong
+# `get_interim_file_url_pro` endpoint (ijai-only, see map_url_endpoint())
+# instead of the plain `get_interim_file_url` this family actually needs, and
+# would hand a JSON blob to the ijai protobuf parser even if the URL fetch
+# succeeded. Needs a live camera-entity retest to confirm; ov43gb is added on
+# spec-family grounds only (no real device to test against yet).
 _XIAOMI_JSON_MAP_PROFILES = frozenset({
     "xiaomi.e101gb",
     "xiaomi.ov21gl",
     "xiaomi.ov31gl",
+    "xiaomi.ov42gl",
+    "xiaomi.ov43gb",
     "xiaomi.ov71gl",
     "xiaomi.ov81gl",
 })

--- a/custom_components/xiaomi_vac/spec/profiles/xiaomi.py
+++ b/custom_components/xiaomi_vac/spec/profiles/xiaomi.py
@@ -907,6 +907,20 @@ XIAOMI_OV43GB = replace(
     notes=("urn:miot-spec-v2:device:vacuum:0000A006:xiaomi-ov43gb:2",),
 )
 
+# xiaomi.vacuum.ov42gl (Xiaomi Robot Vacuum H50 Pro) — identical spec layout
+# to ov21gl. Unlike ov71gl/ov43gb (unverified aliases), this one is confirmed
+# against a real device's spec cache AND the public MIoT spec DB: every
+# siid/piid/aiid in the vendored ov42gl spec matches ov21gl's core exactly,
+# and the public value-lists for status (all 24 codes), fan_speed (piid 2/9,
+# despite the generic "mode" MIoT type), water_level (piid 2/10), mode
+# (piid 2/4, "Sweep Mop Type"), and sweep_type (piid 2/5) match ov21gl's
+# tables 1:1.
+XIAOMI_OV42GL = replace(
+    XIAOMI_OV21GL,
+    profile_id='xiaomi.ov42gl',
+    notes=("urn:miot-spec-v2:device:vacuum:0000A006:xiaomi-ov42gl:2",),
+)
+
 # c107/d101/d102ev/d102gl/d109gl: same siid/piid layout as ov21gl, but their
 # sweep-type value list stops at 7. status_map keeps the full ov21gl table —
 # codes 22-24 are simply never reported by the shorter-spec models.

--- a/custom_components/xiaomi_vac/spec/registry.py
+++ b/custom_components/xiaomi_vac/spec/registry.py
@@ -53,6 +53,7 @@ from .profiles.xiaomi import (
     XIAOMI_D109GL,
     XIAOMI_D110CH,
     XIAOMI_OV21GL,
+    XIAOMI_OV42GL,
     XIAOMI_OV43GB,
     XIAOMI_OV71GL,
 )
@@ -94,6 +95,7 @@ MODEL_PROFILES: dict[str, ModelProfile] = {
     "xiaomi.vacuum.d109gl": XIAOMI_D109GL,
     "xiaomi.vacuum.d110ch": XIAOMI_D110CH,
     "xiaomi.vacuum.ov21gl": XIAOMI_OV21GL,
+    "xiaomi.vacuum.ov42gl": XIAOMI_OV42GL,
     "xiaomi.vacuum.ov43gb": XIAOMI_OV43GB,
     "xiaomi.vacuum.ov71gl": XIAOMI_OV71GL,
     # --- viomi --------------------------------------------------------------

--- a/custom_components/xiaomi_vac/www/xiaomi-vac-card.js
+++ b/custom_components/xiaomi_vac/www/xiaomi-vac-card.js
@@ -40,7 +40,7 @@ const modelShort = (m) => {
 };
 // shape 1 is the default fallback for unmapped models
 const MODEL_SHAPE = Object.fromEntries([
-  [1, ["dreame.mb1808","dreame.mc1808","xiaomi.ov21gl","xiaomi.ov43gb","dreame.md1808","dreame.p2008","dreame.p2140a","dreame.p2140o","dreame.p2140p","ijai.v10","ijai.v14"]],
+  [1, ["dreame.mb1808","dreame.mc1808","xiaomi.ov21gl","xiaomi.ov42gl","xiaomi.ov43gb","dreame.md1808","dreame.p2008","dreame.p2140a","dreame.p2140o","dreame.p2140p","ijai.v10","ijai.v14"]],
   [2, ["dreame.p2029","dreame.p2028","dreame.p2028a","dreame.p2150b","dreame.p2150o"]],
   [3, ["ijai.v2","ijai.v3","xiaomi.c104","rockrobo.v1","xiaomi.d110ch","xiaomi.d103cn","xiaomi.d102gl","xiaomi.d102ev","xiaomi.d101","xiaomi.c107","xiaomi.c102gl","xiaomi.c102cn","xiaomi.c101eu","xiaomi.c101","dreame.p2114a","dreame.p2114o","dreame.r2210","dreame.r2209","dreame.r2211o","dreame.r2228","dreame.r2228o","dreame.r2228z","dreame.r2232a","dreame.r2233","dreame.r2246","dreame.r2247","dreame.r2254","dreame.s5"]],
   [4, ["ijai.v17","ijai.v18","ijai.v19","xiaomi.b106eu"]],

--- a/custom_components/xiaomi_vac/xiaomi_json_decrypt.py
+++ b/custom_components/xiaomi_vac/xiaomi_json_decrypt.py
@@ -1,0 +1,53 @@
+"""Decrypt a Xiaomi "version 2" JSON-enveloped cloud map blob.
+
+Bypasses `vacuum_map_parser_xiaomi.aes_decryptor.decrypt()`, which is broken
+for every model in `_XIAOMI_JSON_MAP_PROFILES` (map_parsers.py): it uses the
+full MIoT model string (always 20 chars for this family, e.g.
+"xiaomi.vacuum.ov42gl") directly as the AES key, which pycryptodome rejects
+outright (`ValueError: Incorrect AES key length`). It also never unwraps the
+`{"version":2,"data":"<base64>"}` envelope this cloud endpoint returns before
+handing bytes to AES — it expects a bare hex-ciphertext string instead.
+
+Reverse-engineered 2026-07-31 from the real Xiaomi Home Android app's
+dynamically-downloaded RN plugin (`com.xiaomi.robovac` bundle, readable
+un-minified crypto section): the AES key is derived from only the model
+string's LAST 16 characters (`Device.model.slice(-16)` in the app's JS) —
+exactly one AES-128 key length, unlike the raw 20-char string. Verified
+against a real captured blob for xiaomi.vacuum.ov42gl (produced valid JSON
+map data end to end).
+"""
+from __future__ import annotations
+
+import base64
+import hashlib
+import json
+import zlib
+
+from Crypto.Cipher import AES
+from Crypto.Util.Padding import pad, unpad
+
+_IV = b"ABCDEF1234123412"
+
+
+def decrypt_xiaomi_json_map(raw: bytes, model: str, device_id: str) -> str:
+    """Decrypt+decompress a version-2 Xiaomi cloud map blob to its JSON text.
+
+    `raw` is the exact bytes downloaded from the cloud map URL: a JSON
+    envelope `{"version":2,"data":"<base64 ciphertext>"}`. Raises ValueError/
+    KeyError/zlib.error/UnicodeDecodeError on anything that doesn't match
+    this shape or fails to decrypt — callers should treat any exception here
+    as "undecryptable blob", same as an upstream decrypt failure.
+    """
+    envelope = json.loads(raw)
+    if envelope.get("version") != 2:
+        raise ValueError(f"unsupported xiaomi map blob version: {envelope.get('version')!r}")
+
+    ciphertext = base64.b64decode(envelope["data"])
+
+    model_key = model[-16:].encode("latin1")
+    original_work = model_key + device_id.encode("latin1")
+    enc_key = AES.new(model_key, AES.MODE_CBC, _IV).encrypt(pad(original_work, AES.block_size))
+    decrypt_key = hashlib.md5(enc_key).digest()
+
+    plaintext = unpad(AES.new(decrypt_key, AES.MODE_CBC, _IV).decrypt(ciphertext), AES.block_size)
+    return zlib.decompress(plaintext).decode("utf-8")

--- a/tests/harness/test_coordinator.py
+++ b/tests/harness/test_coordinator.py
@@ -253,9 +253,13 @@ async def test_map_coordinator_session_expiry_triggers_pass_token_refresh(
 
     fake_result = _fake_result(map_id=1)
     fetcher = MagicMock()
-    # First attempt: slot "0" raises SessionExpired (short-circuits slot "1").
-    # Retry after refresh: slot "0" decodes, slot "1" doesn't.
-    fetcher.fetch.side_effect = [SessionExpired("token dead"), fake_result, None]
+    # First attempt: both slots raise SessionExpired (every slot is tried
+    # independently now, so a refresh is only triggered once neither
+    # resolves). Retry after refresh: slot "0" decodes, slot "1" doesn't.
+    fetcher.fetch.side_effect = [
+        SessionExpired("token dead"), SessionExpired("token dead"),
+        fake_result, None,
+    ]
     coord._fetcher = fetcher
 
     async def _exec(fn, *a):
@@ -293,6 +297,68 @@ async def test_map_coordinator_session_expiry_refresh_fails_raises_auth_failed(
         pytest.raises(ConfigEntryAuthFailed),
     ):
         await coord._async_update_data()
+
+
+async def test_map_coordinator_session_still_expired_after_refresh_raises_update_failed(
+    hass: HomeAssistant,
+) -> None:
+    """A second SessionExpired right after a *successful* passToken refresh is
+    not an auth problem (refresh just proved the credentials are good) — it
+    must surface as UpdateFailed, not bounce the user back into reauth."""
+    coord = _map_coord(hass)
+
+    fetcher = MagicMock()
+    fetcher.fetch.side_effect = SessionExpired("dead")
+    coord._fetcher = fetcher
+
+    async def _exec(fn, *a):
+        return fn(*a)
+
+    with (
+        patch.object(coord, "_refresh_and_persist", new=AsyncMock(return_value=True)),
+        patch.object(coord, "_ensure_cache", new=AsyncMock(return_value=_FakeCache())),
+        patch.object(hass, "async_add_executor_job", new=AsyncMock(side_effect=_exec)),
+        pytest.raises(UpdateFailed),
+    ):
+        await coord._async_update_data()
+
+
+async def test_map_coordinator_serves_surviving_slot_when_other_slot_is_permanently_dead(
+    hass: HomeAssistant,
+) -> None:
+    """One cloud object (e.g. Map Obj Name) can be permanently unavailable
+    ("-6 invalid config for fds"-style) while a different object for the
+    same device (e.g. Trajectory Obj Name) still resolves fine. _fetch_slots
+    must try every slot independently and serve from whichever one works,
+    never demanding a reauth just because ONE slot is dead."""
+    coord = _map_coord(hass)
+
+    fake_result = _fake_result(map_id=1)
+    fetcher = MagicMock()
+
+    def _fetch(slot):
+        if slot == "0":
+            raise SessionExpired("this object is permanently dead")
+        return fake_result
+
+    fetcher.fetch.side_effect = _fetch
+    coord._fetcher = fetcher
+
+    async def _exec(fn, *a):
+        return fn(*a)
+
+    mock_refresh = AsyncMock(return_value=True)
+    with (
+        patch.object(coord, "_refresh_and_persist", new=mock_refresh),
+        patch.object(coord, "_ensure_cache", new=AsyncMock(return_value=_FakeCache())),
+        patch.object(hass, "async_add_executor_job", new=AsyncMock(side_effect=_exec)),
+    ):
+        result = await coord._async_update_data()
+
+    assert result.map_id == fake_result.map_id
+    assert result.image_png == fake_result.image_png
+    # Slot "1" resolved on the very first pass — no refresh/reauth needed.
+    mock_refresh.assert_not_awaited()
 
 
 async def test_map_coordinator_none_result_resets_fetcher_and_raises(

--- a/tests/pure/test_connector_map_url.py
+++ b/tests/pure/test_connector_map_url.py
@@ -1,0 +1,72 @@
+"""Pure tests for XiaomiCloud.map_url()'s endpoint-fallback logic.
+
+Live-diagnosed 2026-07-31: for some accounts/models (observed: 3irobotic-
+manufactured xiaomi.* models like ov42gl) the "wrong" endpoint fails with
+code -6 ("invalid config for fds"), not the -8 the old fallback trigger
+checked for. map_url() must now try the alternate endpoint on ANY failure,
+not just a specific error code.
+"""
+from __future__ import annotations
+
+from unittest.mock import patch
+
+from cloud.connector import XiaomiCloud
+
+
+def _cloud() -> XiaomiCloud:
+    cloud = XiaomiCloud("user@example.com")
+    cloud.user_id = "1697322470"
+    return cloud
+
+
+def test_map_url_succeeds_on_first_endpoint_without_trying_alternate():
+    cloud = _cloud()
+    with patch.object(cloud, "_call", return_value={"code": 0, "result": {"url": "https://a"}}) as mock_call:
+        url = cloud.map_url("de", "123", "0", endpoint="get_interim_file_url_pro")
+    assert url == "https://a"
+    mock_call.assert_called_once()
+
+
+def test_map_url_falls_back_on_code_minus6_not_just_minus8():
+    cloud = _cloud()
+    responses = [
+        {"code": -6, "message": "invalid config for fds", "result": None},
+        {"code": 0, "message": "ok", "result": {"url": "https://alt"}},
+    ]
+    with patch.object(cloud, "_call", side_effect=responses) as mock_call:
+        url = cloud.map_url("de", "123", "0", endpoint="get_interim_file_url")
+    assert url == "https://alt"
+    assert mock_call.call_count == 2
+    # Second call must hit the *other* endpoint.
+    second_url = mock_call.call_args_list[1].args[0]
+    assert "get_interim_file_url_pro" in second_url
+
+
+def test_map_url_still_falls_back_on_code_minus8():
+    cloud = _cloud()
+    responses = [
+        {"code": -8, "message": "rejected", "result": None},
+        {"code": 0, "message": "ok", "result": {"url": "https://alt"}},
+    ]
+    with patch.object(cloud, "_call", side_effect=responses):
+        url = cloud.map_url("de", "123", "0", endpoint="get_interim_file_url_pro")
+    assert url == "https://alt"
+
+
+def test_map_url_returns_none_when_both_endpoints_fail():
+    cloud = _cloud()
+    responses = [
+        {"code": -6, "message": "invalid config for fds", "result": None},
+        {"code": -6, "message": "invalid config for fds", "result": None},
+    ]
+    with patch.object(cloud, "_call", side_effect=responses):
+        url = cloud.map_url("de", "123", "0", endpoint="get_interim_file_url")
+    assert url is None
+
+
+def test_map_url_returns_none_when_call_itself_returns_none():
+    """A non-200 HTTP status makes `_call` return None (see connector.py)."""
+    cloud = _cloud()
+    with patch.object(cloud, "_call", return_value=None):
+        url = cloud.map_url("de", "123", "0")
+    assert url is None

--- a/tests/pure/test_connector_map_url.py
+++ b/tests/pure/test_connector_map_url.py
@@ -15,7 +15,7 @@ from cloud.connector import XiaomiCloud
 
 def _cloud() -> XiaomiCloud:
     cloud = XiaomiCloud("user@example.com")
-    cloud.user_id = "1697322470"
+    cloud.user_id = "9876543210"
     return cloud
 
 

--- a/tests/pure/test_map.py
+++ b/tests/pure/test_map.py
@@ -140,6 +140,8 @@ def _profile(brand: str, profile_id: str):
         ("xiaomi", "xiaomi.e101gb", "xiaomi"),
         ("xiaomi", "xiaomi.ov21gl", "xiaomi"),
         ("xiaomi", "xiaomi.ov31gl", "xiaomi"),
+        ("xiaomi", "xiaomi.ov42gl", "xiaomi"),
+        ("xiaomi", "xiaomi.ov43gb", "xiaomi"),
         ("xiaomi", "xiaomi.ov71gl", "xiaomi"),
         ("xiaomi", "xiaomi.ov81gl", "xiaomi"),
         ("dreame", "dreame.p2008", "dreame"),

--- a/tests/pure/test_registry.py
+++ b/tests/pure/test_registry.py
@@ -23,8 +23,8 @@ def test_registry_counts_match_card_baseline() -> None:
     supported = [model for model in MODEL_PROFILES if is_supported(model)]
     rejected = [model for model in MODEL_PROFILES if not is_supported(model)]
 
-    assert len(MODEL_PROFILES) == 94
-    assert len(supported) == 73
+    assert len(MODEL_PROFILES) == 95
+    assert len(supported) == 74
     assert len(rejected) == 21
 
 

--- a/tests/pure/test_xiaomi_json_decrypt.py
+++ b/tests/pure/test_xiaomi_json_decrypt.py
@@ -1,0 +1,161 @@
+"""Tests for xiaomi_json_decrypt: the version-2 Xiaomi cloud map blob decoder.
+
+Reverse-engineered 2026-07-31 from the real Xiaomi Home Android app's RN
+plugin bundle (see BRIEF.md, round 9). vacuum_map_parser_xiaomi's own
+decrypt() is broken for this whole model family: every profile in
+map_parsers._XIAOMI_JSON_MAP_PROFILES has a 20-char MIoT model string, and
+the upstream package uses that full string directly as the AES key
+(pycryptodome rejects any non-16/24/32-byte key). The real app derives the
+key from only the model string's last 16 characters, and the endpoint wraps
+the ciphertext in a `{"version":2,"data":"<base64>"}` envelope the upstream
+package never unwraps either.
+
+These tests round-trip synthetic data through a from-scratch reimplementation
+of the app's encrypt side (independent of the production decrypt code, so it
+can't share a bug with what it's testing) rather than embedding the real
+captured blob from a live device, which is private user data (a floor plan
+of their home) that doesn't belong in a public test fixture.
+"""
+from __future__ import annotations
+
+import base64
+import hashlib
+import json
+import zlib
+
+import pytest
+from Crypto.Cipher import AES
+from Crypto.Util.Padding import pad
+
+from xiaomi_json_decrypt import decrypt_xiaomi_json_map
+
+# Loaded via the synthetic `xvac` package (see tests/pure/conftest.py) — map.py
+# has relative imports so it can't be imported standalone.
+from xvac.map import MapFetcher
+
+_IV = b"ABCDEF1234123412"
+
+
+def _encrypt_like_the_real_app(payload: dict, *, model: str, device_id: str) -> bytes:
+    """Mirror of the app's map.js encrypt path: the inverse of decrypt_xiaomi_json_map."""
+    model_key = model[-16:].encode("latin1")
+    original_work = model_key + device_id.encode("latin1")
+    enc_key = AES.new(model_key, AES.MODE_CBC, _IV).encrypt(pad(original_work, AES.block_size))
+    encrypt_key = hashlib.md5(enc_key).digest()
+
+    plaintext = zlib.compress(json.dumps(payload).encode("utf-8"))
+    ciphertext = AES.new(encrypt_key, AES.MODE_CBC, _IV).encrypt(pad(plaintext, AES.block_size))
+    envelope = {"version": 2, "data": base64.b64encode(ciphertext).decode("ascii")}
+    return json.dumps(envelope).encode("utf-8")
+
+
+@pytest.mark.parametrize("model", [
+    "xiaomi.vacuum.ov42gl",   # 21 chars, the model that motivated this fix
+    "xiaomi.vacuum.ov21gl",   # 21 chars, an already-"working" (never actually tested) profile
+    "1234567890123456",       # exactly 16 chars: slice(-16) is a no-op
+])
+def test_decrypt_round_trip(model):
+    payload = {"map_id": 4, "height": 160, "width": 256, "map_data": "abc123"}
+    blob = _encrypt_like_the_real_app(payload, model=model, device_id="1190991420")
+    result = json.loads(decrypt_xiaomi_json_map(blob, model, "1190991420"))
+    assert result == payload
+
+
+def test_decrypt_uses_only_last_16_chars_of_model():
+    """Two model strings sharing the same last 16 chars must decrypt identically —
+    proves the fix truncates rather than hashing/padding the full string."""
+    payload = {"ok": True}
+    device_id = "1190991420"
+    long_model = "xiaomi.vacuum.ov42gl"
+    same_suffix_model = "zzzzz" + long_model[-16:]
+    assert long_model[-16:] == same_suffix_model[-16:]
+
+    blob = _encrypt_like_the_real_app(payload, model=long_model, device_id=device_id)
+    result = json.loads(decrypt_xiaomi_json_map(blob, same_suffix_model, device_id))
+    assert result == payload
+
+
+def test_decrypt_rejects_wrong_version():
+    envelope = json.dumps({"version": 1, "data": "irrelevant"}).encode("utf-8")
+    with pytest.raises(ValueError, match="unsupported xiaomi map blob version"):
+        decrypt_xiaomi_json_map(envelope, "xiaomi.vacuum.ov42gl", "1190991420")
+
+
+def test_decrypt_rejects_non_json_input():
+    with pytest.raises(json.JSONDecodeError):
+        decrypt_xiaomi_json_map(b"not json at all", "xiaomi.vacuum.ov42gl", "1190991420")
+
+
+def test_decrypt_rejects_wrong_key_material():
+    """A blob encrypted for one device must not silently decrypt for another —
+    either PKCS7 unpadding or the trailing zlib decompress must reject it."""
+    payload = {"map_id": 1}
+    blob = _encrypt_like_the_real_app(payload, model="xiaomi.vacuum.ov42gl", device_id="1190991420")
+    with pytest.raises(Exception):  # noqa: B017 - either ValueError (unpad) or zlib.error
+        decrypt_xiaomi_json_map(blob, "xiaomi.vacuum.ov42gl", "9999999999")
+
+
+# --- MapFetcher integration: _unpack must bypass the broken upstream
+# decrypt() entirely for the "xiaomi" brand, and the result must be usable
+# downstream (parser.parse() wants str/dict; MapFetcher.fetch() also hashes
+# it with hashlib.sha256, which only accepts bytes) ------------------------
+class FakeCloud:
+    def __init__(self, *, url="http://x", blob=b""):
+        self.url = url
+        self.blob = blob
+
+    def map_url(self, server, did, slot, endpoint):
+        return self.url
+
+    def download(self, url):
+        return self.blob
+
+
+def test_mapfetcher_unpack_xiaomi_bypasses_upstream_decrypt():
+    """_unpack must never call parser.unpack_map for brand=='xiaomi' — that
+    upstream path is what's broken (see module docstring)."""
+    model = "xiaomi.vacuum.ov42gl"
+    payload = {"map_id": 4, "height": 160, "width": 256}
+    blob = _encrypt_like_the_real_app(payload, model=model, device_id="1190991420")
+
+    fetcher = MapFetcher(
+        FakeCloud(), server="de", user_id="1", device_id="1190991420", model=model,
+        mac="AA:BB:CC:DD:EE:FF", wifi_sn="SN", parser_brand="xiaomi")
+
+    def _boom(*a, **kw):
+        raise AssertionError("upstream vacuum_map_parser_xiaomi.unpack_map must not be called")
+    fetcher._parser.unpack_map = _boom
+
+    unpacked = fetcher._unpack(blob)
+    assert isinstance(unpacked, str)
+    assert json.loads(unpacked) == payload
+
+
+def test_mapfetcher_fetch_full_chain_xiaomi_json():
+    """End-to-end: fetch() -> decrypt -> parser.parse() -> content_hash, no crash.
+
+    Regression guard for the latent `hashlib.sha256(str)` TypeError: xiaomi's
+    _unpack returns a JSON *string* (matching parser.parse()'s str/dict-only
+    contract), which used to reach the bare `hashlib.sha256(unpacked)` call
+    unencoded.
+    """
+    model = "xiaomi.vacuum.ov42gl"
+    payload = {
+        "map_id": 4, "map_type": 1, "height": 4, "width": 4,
+        "resolution": 50, "origin_x": 0, "origin_y": 0,
+        "map_data": base64.b64encode(zlib.compress(bytes([1] * 16))).decode("ascii"),
+    }
+    blob = _encrypt_like_the_real_app(payload, model=model, device_id="1190991420")
+
+    fetcher = MapFetcher(
+        FakeCloud(blob=blob), server="de", user_id="1", device_id="1190991420", model=model,
+        mac="AA:BB:CC:DD:EE:FF", wifi_sn="SN", parser_brand="xiaomi")
+
+    result = fetcher.fetch()
+    # Whatever the parser/vector layer makes of this minimal synthetic frame,
+    # it must not raise — that's the regression this test guards against.
+    # A None result (parser rejected the frame / empty image) is an
+    # acceptable outcome here since the payload is synthetic, not a real map.
+    if result is not None:
+        assert isinstance(result.content_hash, str)
+        assert len(result.content_hash) == 64  # sha256 hex digest

--- a/tests/pure/test_xiaomi_json_decrypt.py
+++ b/tests/pure/test_xiaomi_json_decrypt.py
@@ -56,8 +56,8 @@ def _encrypt_like_the_real_app(payload: dict, *, model: str, device_id: str) -> 
 ])
 def test_decrypt_round_trip(model):
     payload = {"map_id": 4, "height": 160, "width": 256, "map_data": "abc123"}
-    blob = _encrypt_like_the_real_app(payload, model=model, device_id="1190991420")
-    result = json.loads(decrypt_xiaomi_json_map(blob, model, "1190991420"))
+    blob = _encrypt_like_the_real_app(payload, model=model, device_id="1234567890")
+    result = json.loads(decrypt_xiaomi_json_map(blob, model, "1234567890"))
     assert result == payload
 
 
@@ -65,7 +65,7 @@ def test_decrypt_uses_only_last_16_chars_of_model():
     """Two model strings sharing the same last 16 chars must decrypt identically —
     proves the fix truncates rather than hashing/padding the full string."""
     payload = {"ok": True}
-    device_id = "1190991420"
+    device_id = "1234567890"
     long_model = "xiaomi.vacuum.ov42gl"
     same_suffix_model = "zzzzz" + long_model[-16:]
     assert long_model[-16:] == same_suffix_model[-16:]
@@ -78,19 +78,19 @@ def test_decrypt_uses_only_last_16_chars_of_model():
 def test_decrypt_rejects_wrong_version():
     envelope = json.dumps({"version": 1, "data": "irrelevant"}).encode("utf-8")
     with pytest.raises(ValueError, match="unsupported xiaomi map blob version"):
-        decrypt_xiaomi_json_map(envelope, "xiaomi.vacuum.ov42gl", "1190991420")
+        decrypt_xiaomi_json_map(envelope, "xiaomi.vacuum.ov42gl", "1234567890")
 
 
 def test_decrypt_rejects_non_json_input():
     with pytest.raises(json.JSONDecodeError):
-        decrypt_xiaomi_json_map(b"not json at all", "xiaomi.vacuum.ov42gl", "1190991420")
+        decrypt_xiaomi_json_map(b"not json at all", "xiaomi.vacuum.ov42gl", "1234567890")
 
 
 def test_decrypt_rejects_wrong_key_material():
     """A blob encrypted for one device must not silently decrypt for another —
     either PKCS7 unpadding or the trailing zlib decompress must reject it."""
     payload = {"map_id": 1}
-    blob = _encrypt_like_the_real_app(payload, model="xiaomi.vacuum.ov42gl", device_id="1190991420")
+    blob = _encrypt_like_the_real_app(payload, model="xiaomi.vacuum.ov42gl", device_id="1234567890")
     with pytest.raises(Exception):  # noqa: B017 - either ValueError (unpad) or zlib.error
         decrypt_xiaomi_json_map(blob, "xiaomi.vacuum.ov42gl", "9999999999")
 
@@ -116,10 +116,10 @@ def test_mapfetcher_unpack_xiaomi_bypasses_upstream_decrypt():
     upstream path is what's broken (see module docstring)."""
     model = "xiaomi.vacuum.ov42gl"
     payload = {"map_id": 4, "height": 160, "width": 256}
-    blob = _encrypt_like_the_real_app(payload, model=model, device_id="1190991420")
+    blob = _encrypt_like_the_real_app(payload, model=model, device_id="1234567890")
 
     fetcher = MapFetcher(
-        FakeCloud(), server="de", user_id="1", device_id="1190991420", model=model,
+        FakeCloud(), server="de", user_id="1", device_id="1234567890", model=model,
         mac="AA:BB:CC:DD:EE:FF", wifi_sn="SN", parser_brand="xiaomi")
 
     def _boom(*a, **kw):
@@ -145,10 +145,10 @@ def test_mapfetcher_fetch_full_chain_xiaomi_json():
         "resolution": 50, "origin_x": 0, "origin_y": 0,
         "map_data": base64.b64encode(zlib.compress(bytes([1] * 16))).decode("ascii"),
     }
-    blob = _encrypt_like_the_real_app(payload, model=model, device_id="1190991420")
+    blob = _encrypt_like_the_real_app(payload, model=model, device_id="1234567890")
 
     fetcher = MapFetcher(
-        FakeCloud(blob=blob), server="de", user_id="1", device_id="1190991420", model=model,
+        FakeCloud(blob=blob), server="de", user_id="1", device_id="1234567890", model=model,
         mac="AA:BB:CC:DD:EE:FF", wifi_sn="SN", parser_brand="xiaomi")
 
     result = fetcher.fetch()


### PR DESCRIPTION
## Summary

Adds `xiaomi.vacuum.ov42gl` (Xiaomi Robot Vacuum H50 Pro) as a supported model, with full device control and — after tracking down a real upstream decrypt bug — a working map camera too.

The model profile is cloned from `xiaomi.vacuum.ov21gl`'s core capabilities and confirmed against a real device: a live `xiaomi_home` MIoT entity dump on an actual H50 Pro shows the identical siid=2 control layout and the same siid=10 vacuum-map service (Map Obj Name / Trajectory Obj Name / Map Management / Room Information) as ov21gl, and the public MIoT spec DB value-lists for status, fan_speed, water_level, mode, and sweep_type all match ov21gl's tables 1:1.

## Bugs fixed along the way

Getting the map camera working past `unavailable` surfaced three separate, real bugs — not just a missing model profile:

1. **`XiaomiCloud.map_url()` only retried the alternate cloud endpoint (`get_interim_file_url` vs. `_pro`) on error code `-8`.** This device fails with `-6 invalid config for fds` instead, so the fallback never fired. (Side note: the object path the cloud returns for this device is literally `3irobotic-ov42gl/...` — it's OEM-manufactured, which probably explains why a "xiaomi"-brand model needs the `_pro` endpoint at all.) `map_url()` now retries on any failure, not a specific error code.
2. **`map_parsers.py` routed `ov42gl` to the ijai parser/endpoint family** instead of the xiaomi JSON one, despite sharing the exact same siid=10 map service as the already-supported ov21gl/ov71gl/etc. (`ov43gb`, already registered, had the same routing bug — fixed alongside it on spec-family grounds, though I don't have hardware to confirm that one.)
3. **`MapFetcher._fetch_slots()` short-circuited on the first slot's `SessionExpired`**, so a permanently-dead slot (e.g. "0") silently prevented a working slot ("1") from ever being tried, and could trigger unnecessary reauth for tokens that were actually still valid.

## The real blocker: `vacuum-map-parser-xiaomi==0.1.4`'s `decrypt()` is broken for its entire supported model list

After fixing the above, every model in `_XIAOMI_JSON_MAP_PROFILES` — not just ov42gl, also `e101gb`, `ov21gl`, `ov31gl`, `ov71gl`, `ov81gl` — still failed to decrypt. Two bugs in the pinned package's `aes_decryptor.py`:

- `decrypt()` uses the *full* MIoT model string as the AES key. Every model in this family is exactly 20 characters — never a valid 16/24/32-byte AES key length — so pycryptodome throws `Incorrect AES key length` unconditionally. As far as I can tell, this means the package has never actually successfully decrypted a map for *any* model it claims to support.
- It also never unwraps the `{"version":2,"data":"<base64>"}` envelope this cloud endpoint returns before handing bytes to AES.

I confirmed the real algorithm by capturing traffic from the official Xiaomi Home Android app (rooted-emulator MITM of its own dynamically-downloaded map-rendering plugin) and reading its un-minified decrypt code: the AES key is derived from only the **last 16 characters** of the model string, and the base64-decoded `data` field goes straight into AES-CBC (no extra hex round-trip needed). I verified this end to end against a real captured map blob from the device: correct PNG output, correct room count, correct dimensions.

Rather than depend on an upstream fix — and since the missing envelope-unwrap means a key-length patch alone wouldn't be enough anyway — this PR adds `xiaomi_json_decrypt.py`, a small, self-contained reimplementation that bypasses `vacuum_map_parser_xiaomi`'s own `decrypt()` entirely, the same way this codebase already bypasses dreame's zero-IV path for that brand. I'm filing a corresponding issue against `vacuum-map-parser-xiaomi` separately, since the bug affects every consumer of that package, not just this integration.

One more, previously-latent bug in this repo's own `map.py` is fixed alongside it: `MapFetcher.fetch()` hashed the unpacked map with `hashlib.sha256(unpacked)`, which throws on a `str` (xiaomi's decrypted output is JSON text, not bytes). It never actually triggered before, because the upstream decrypt bug always threw first.

## Testing

- `tests/pure`: 737/737 passing — 9 new tests in `tests/pure/test_xiaomi_json_decrypt.py`, 5 in `tests/pure/test_connector_map_url.py`. All synthetic round-trip fixtures; no real device data included.
- Manually verified the full `MapFetcher.fetch()` chain (download → decrypt → parse → render) against a real captured map blob from a live H50 Pro: produced a correct PNG with the expected room count and dimensions.
- Device control (start/stop/dock/battery/fan_speed/water_level/cleaning_mode/sweep_type/volume/locate) verified live against a real device.
- `tests/pure/test_registry.py` counts updated (94→95 models, 73→74 supported).

## Notes for review

- Per the contributing note about stripping account identifiers from anything posted publicly: the test fixtures use arbitrary placeholder device/account IDs, not the ones from my actual testing.
- `ov43gb`'s parser routing fix is spec-inference only (same profile family as ov21gl/ov42gl) — I don't have that hardware to confirm it end to end.
