### PR TITLE
Add consumable-life sensors (main/side brush, filter, dust bag, detergent) for xiaomi.ov42gl

### DIFF
--- a/custom_components/xiaomi_vac/device.py
+++ b/custom_components/xiaomi_vac/device.py
@@ -131,6 +131,7 @@ class IjaiVacuumDevice:
                 "main_brush_life": cons.main_brush_life,
                 "side_brush_life": cons.side_brush_life,
                 "filter_life": cons.filter_life,
+                "mop_life": cons.mop_life,
                 "dust_bag_life": cons.dust_bag_life,
                 "detergent_life": cons.detergent_life,
             }
@@ -165,7 +166,7 @@ class IjaiVacuumDevice:
             main_brush_life=_as_int(vals.get(cons_props.get("main_brush_life"))),
             side_brush_life=_as_int(vals.get(cons_props.get("side_brush_life"))),
             filter_life=_as_int(vals.get(cons_props.get("filter_life"))),
-            mop_life=None,
+            mop_life=_as_int(vals.get(cons_props.get("mop_life"))),
             dust_bag_life=_as_int(vals.get(cons_props.get("dust_bag_life"))),
             detergent_life=_as_int(vals.get(cons_props.get("detergent_life"))),
             clean_area=None,

--- a/custom_components/xiaomi_vac/device.py
+++ b/custom_components/xiaomi_vac/device.py
@@ -8,7 +8,7 @@ from dataclasses import dataclass
 from miio import MiotDevice
 
 from .spec.registry import card_baseline_gaps, get_profile
-from .spec.types import CoreCapability, MapCapability, ModelProfile
+from .spec.types import CoreCapability, DreameConsumablesCapability, MapCapability, ModelProfile
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -45,6 +45,8 @@ class VacuumStatus:
     side_brush_life: int | None
     filter_life: int | None
     mop_life: int | None
+    dust_bag_life: int | None
+    detergent_life: int | None
     clean_area: int | None
     clean_time: int | None
 
@@ -116,13 +118,28 @@ class IjaiVacuumDevice:
     # --- telemetry -------------------------------------------------------
     def status(self) -> VacuumStatus:
         c = self.core
-        # Lean core (decision 2026-06-25): consumable life and clean-area/time
-        # are NOT in core; they're parked at launch -> always None here.
+        # Lean core (decision 2026-06-25): clean-area/time are still NOT in
+        # core, parked -> always None below. Consumable life (2026-08-01):
+        # populated when profile.consumables is the percent+hours-shaped
+        # DreameConsumablesCapability (life-level props only here — the
+        # left-time/hours props exist on the profile but aren't polled, no
+        # consumer needs them yet).
+        cons = self.profile.consumables
+        cons_props: dict[str, "object"] = {}
+        if isinstance(cons, DreameConsumablesCapability):
+            cons_props = {
+                "main_brush_life": cons.main_brush_life,
+                "side_brush_life": cons.side_brush_life,
+                "filter_life": cons.filter_life,
+                "dust_bag_life": cons.dust_bag_life,
+                "detergent_life": cons.detergent_life,
+            }
         # Batch all non-None props in one get_properties call (chunked when
         # profile.max_properties is set — e.g. IJAI_CORE_LEGACY devices).
         poll = [p for p in (
             c.status, c.battery, c.fault, c.fan_speed, c.water_level,
             c.mode, c.sweep_type, c.repeat, c.alarm, c.volume,
+            *cons_props.values(),
         ) if p is not None]
         vals = self._batch_get(poll)
         _raw = vals.get(c.status)
@@ -145,10 +162,12 @@ class IjaiVacuumDevice:
             repeat_raw=_as_int(vals.get(c.repeat)),
             alarm_raw=_as_int(vals.get(c.alarm)),
             volume_raw=_as_int(vals.get(c.volume)),
-            main_brush_life=None,
-            side_brush_life=None,
-            filter_life=None,
+            main_brush_life=_as_int(vals.get(cons_props.get("main_brush_life"))),
+            side_brush_life=_as_int(vals.get(cons_props.get("side_brush_life"))),
+            filter_life=_as_int(vals.get(cons_props.get("filter_life"))),
             mop_life=None,
+            dust_bag_life=_as_int(vals.get(cons_props.get("dust_bag_life"))),
+            detergent_life=_as_int(vals.get(cons_props.get("detergent_life"))),
             clean_area=None,
             clean_time=None,
         )

--- a/custom_components/xiaomi_vac/sensor.py
+++ b/custom_components/xiaomi_vac/sensor.py
@@ -79,6 +79,12 @@ _ALL_SENSORS: tuple[XiaomiSensorDescription, ...] = (
         supported_fn=_has_consumable("filter_life"),
     ),
     XiaomiSensorDescription(
+        key="mop_life", translation_key="mop_life", icon="mdi:layers-triple-outline",
+        native_unit_of_measurement=PERCENTAGE, state_class=SensorStateClass.MEASUREMENT,
+        entity_category=EntityCategory.DIAGNOSTIC, value_fn=lambda s: s.mop_life,
+        supported_fn=_has_consumable("mop_life"),
+    ),
+    XiaomiSensorDescription(
         key="dust_bag_life", translation_key="dust_bag_life", icon="mdi:trash-can-outline",
         native_unit_of_measurement=PERCENTAGE, state_class=SensorStateClass.MEASUREMENT,
         entity_category=EntityCategory.DIAGNOSTIC, value_fn=lambda s: s.dust_bag_life,

--- a/custom_components/xiaomi_vac/sensor.py
+++ b/custom_components/xiaomi_vac/sensor.py
@@ -10,7 +10,7 @@ from homeassistant.components.sensor import (
     SensorEntityDescription,
     SensorStateClass,
 )
-from homeassistant.const import PERCENTAGE
+from homeassistant.const import PERCENTAGE, EntityCategory
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.device_registry import DeviceInfo
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
@@ -20,7 +20,7 @@ from . import XiaomiConfigEntry
 from .const import DOMAIN
 from .coordinator import XiaomiVacuumCoordinator
 from .device import VacuumStatus
-from .spec.types import ModelProfile
+from .spec.types import DreameConsumablesCapability, ModelProfile
 
 # Read-only platform fed by the coordinator; no device writes to serialise.
 PARALLEL_UPDATES = 0
@@ -34,10 +34,18 @@ class XiaomiSensorDescription(SensorEntityDescription):
     supported_fn: Callable[[ModelProfile], bool] | None = None
 
 
-# Canonical sensor catalogue.  Sensors whose data the coordinator cannot yet
-# populate (consumable-life, clean area/time — parked pending a dedicated
-# coordinator) are omitted here; they will be re-added with a supported_fn
-# predicate once the implementation is in place.
+def _has_consumable(attr: str) -> Callable[[ModelProfile], bool]:
+    """supported_fn factory: True when profile.consumables is the
+    percent+hours-shaped DreameConsumablesCapability AND has `attr` set."""
+    return lambda p: (
+        isinstance(p.consumables, DreameConsumablesCapability)
+        and getattr(p.consumables, attr) is not None
+    )
+
+
+# Canonical sensor catalogue.  Clean area/time still have no populating
+# coordinator support and stay omitted; consumable-life (2026-08-01) is now
+# wired end to end (device.py polls it, gated the same way below).
 _ALL_SENSORS: tuple[XiaomiSensorDescription, ...] = (
     XiaomiSensorDescription(
         key="status", translation_key="status",
@@ -51,6 +59,36 @@ _ALL_SENSORS: tuple[XiaomiSensorDescription, ...] = (
         device_class=SensorDeviceClass.BATTERY, native_unit_of_measurement=PERCENTAGE,
         state_class=SensorStateClass.MEASUREMENT, value_fn=lambda s: s.battery,
         supported_fn=lambda p: p.core is not None and p.core.battery is not None,
+    ),
+    XiaomiSensorDescription(
+        key="main_brush_life", translation_key="main_brush_life", icon="mdi:broom",
+        native_unit_of_measurement=PERCENTAGE, state_class=SensorStateClass.MEASUREMENT,
+        entity_category=EntityCategory.DIAGNOSTIC, value_fn=lambda s: s.main_brush_life,
+        supported_fn=_has_consumable("main_brush_life"),
+    ),
+    XiaomiSensorDescription(
+        key="side_brush_life", translation_key="side_brush_life", icon="mdi:broom",
+        native_unit_of_measurement=PERCENTAGE, state_class=SensorStateClass.MEASUREMENT,
+        entity_category=EntityCategory.DIAGNOSTIC, value_fn=lambda s: s.side_brush_life,
+        supported_fn=_has_consumable("side_brush_life"),
+    ),
+    XiaomiSensorDescription(
+        key="filter_life", translation_key="filter_life", icon="mdi:air-filter",
+        native_unit_of_measurement=PERCENTAGE, state_class=SensorStateClass.MEASUREMENT,
+        entity_category=EntityCategory.DIAGNOSTIC, value_fn=lambda s: s.filter_life,
+        supported_fn=_has_consumable("filter_life"),
+    ),
+    XiaomiSensorDescription(
+        key="dust_bag_life", translation_key="dust_bag_life", icon="mdi:trash-can-outline",
+        native_unit_of_measurement=PERCENTAGE, state_class=SensorStateClass.MEASUREMENT,
+        entity_category=EntityCategory.DIAGNOSTIC, value_fn=lambda s: s.dust_bag_life,
+        supported_fn=_has_consumable("dust_bag_life"),
+    ),
+    XiaomiSensorDescription(
+        key="detergent_life", translation_key="detergent_life", icon="mdi:cup-water",
+        native_unit_of_measurement=PERCENTAGE, state_class=SensorStateClass.MEASUREMENT,
+        entity_category=EntityCategory.DIAGNOSTIC, value_fn=lambda s: s.detergent_life,
+        supported_fn=_has_consumable("detergent_life"),
     ),
 )
 

--- a/custom_components/xiaomi_vac/spec/profiles/xiaomi.py
+++ b/custom_components/xiaomi_vac/spec/profiles/xiaomi.py
@@ -13,6 +13,7 @@ from ..types import (
     ConsumablesCapability,
     CoreCapability,
     DndCapability,
+    DreameConsumablesCapability,
     MapCapability,
     ModelProfile,
     PointZoneCapability,
@@ -919,6 +920,20 @@ XIAOMI_OV42GL = replace(
     XIAOMI_OV21GL,
     profile_id='xiaomi.ov42gl',
     notes=("urn:miot-spec-v2:device:vacuum:0000A006:xiaomi-ov42gl:2",),
+    # Consumables (2026-08-01): read straight off the live device's own cached
+    # MIoT spec (.storage/xiaomi_home/miot_specs/...xiaomi-ov42gl:1_en.dict),
+    # hardware-confirmed for THIS model — not extended to ov71gl/ov43gb (only
+    # aliased on spec-family grounds, unverified) or ov21gl. Main/side brush
+    # are two separate brush-cleaner service instances (siid 12/13); filter
+    # siid 14; detergent (mop-solution tank) siid 18; dust bag siid 19 — each
+    # exposes life-level (piid 1, %) + left-time (piid 2 or 4, hours).
+    consumables=DreameConsumablesCapability(
+        main_brush_life=Prop(12, 1), main_brush_left_time=Prop(12, 2),
+        side_brush_life=Prop(13, 1), side_brush_left_time=Prop(13, 2),
+        filter_life=Prop(14, 1), filter_left_time=Prop(14, 2),
+        detergent_life=Prop(18, 1), detergent_left_time=Prop(18, 4),
+        dust_bag_life=Prop(19, 1), dust_bag_left_time=Prop(19, 2),
+    ),
 )
 
 # c107/d101/d102ev/d102gl/d109gl: same siid/piid layout as ov21gl, but their

--- a/custom_components/xiaomi_vac/spec/profiles/xiaomi.py
+++ b/custom_components/xiaomi_vac/spec/profiles/xiaomi.py
@@ -883,6 +883,13 @@ XIAOMI_CORE_OV21GL = CoreCapability(
 # xiaomi.vacuum.ov21gl
 # No `map=` MapCapability: multi-map is unsupported by design for this
 # generation — device.map_list() returns [] (see map_parsers.py / device.py).
+# Consumables (2026-08-06): hardware-confirmed by a real ov21gl owner
+# (letitbe-dull/xiaomi-vac#20 comment, tomasloksa) — this model has NO
+# detergent/mop-solution-tank service at all; instead the mop PAD itself
+# carries a life-level (siid 9), unlike ov42gl's separate detergent(18)+
+# no-mop-pad layout. Do not copy this consumables block onto ov71gl/ov43gb
+# (still unverified aliases, see the family-resemblance note above) without
+# separate confirmation.
 XIAOMI_OV21GL = ModelProfile(
     profile_id='xiaomi.ov21gl',
     brand='xiaomi',
@@ -892,20 +899,32 @@ XIAOMI_OV21GL = ModelProfile(
         room_ids=Prop(2, 15),
         start=Action(2, 16, in_piid=15),
     ),
+    consumables=DreameConsumablesCapability(
+        main_brush_life=Prop(12, 1), main_brush_left_time=Prop(12, 2),
+        side_brush_life=Prop(13, 1), side_brush_left_time=Prop(13, 2),
+        filter_life=Prop(14, 1), filter_left_time=Prop(14, 2),
+        mop_life=Prop(9, 1), mop_left_time=Prop(9, 2),
+        dust_bag_life=Prop(19, 1), dust_bag_left_time=Prop(19, 2),
+    ),
 )
 
-# xiaomi.vacuum.ov71gl — identical spec layout to ov21gl
+# xiaomi.vacuum.ov71gl — identical core spec layout to ov21gl, but consumables
+# are unverified on this alias — explicitly cleared so it doesn't silently
+# inherit ov21gl's hardware-confirmed siid/piid table via replace().
 XIAOMI_OV71GL = replace(
     XIAOMI_OV21GL,
     profile_id='xiaomi.ov71gl',
     notes=("urn:miot-spec-v2:device:vacuum:0000A006:xiaomi-ov71gl:1",),
+    consumables=None,
 )
 
-# xiaomi.vacuum.ov43gb — identical spec layout to ov21gl
+# xiaomi.vacuum.ov43gb — identical core spec layout to ov21gl, consumables
+# unverified (see ov71gl note above).
 XIAOMI_OV43GB = replace(
     XIAOMI_OV21GL,
     profile_id='xiaomi.ov43gb',
     notes=("urn:miot-spec-v2:device:vacuum:0000A006:xiaomi-ov43gb:2",),
+    consumables=None,
 )
 
 # xiaomi.vacuum.ov42gl (Xiaomi Robot Vacuum H50 Pro) — identical spec layout
@@ -952,12 +971,15 @@ XIAOMI_CORE_C107 = replace(
     },
 )
 
-# xiaomi.vacuum.c107
+# xiaomi.vacuum.c107 — consumables unverified on this family (see ov71gl note
+# above), explicitly cleared so it and its d10x aliases below don't silently
+# inherit ov21gl's hardware-confirmed siid/piid table via replace().
 XIAOMI_C107 = replace(
     XIAOMI_OV21GL,
     profile_id='xiaomi.c107',
     notes=("urn:miot-spec-v2:device:vacuum:0000A006:xiaomi-c107:2",),
     core=XIAOMI_CORE_C107,
+    consumables=None,
 )
 
 # xiaomi.vacuum.d101 — identical spec layout to c107

--- a/custom_components/xiaomi_vac/spec/types.py
+++ b/custom_components/xiaomi_vac/spec/types.py
@@ -226,7 +226,16 @@ class DreameConsumablesCapability:
     mop_left_time: Prop | None = None
     reset_mop: Action | None = None
     detergent_life: Prop | None = None
+    detergent_left_time: Prop | None = None
     reset_detergent: Action | None = None
+    # dust-bag service (its own siid, e.g. xiaomi.ov42gl's siid 19): added
+    # 2026-08-01 for a xiaomi-brand profile that reuses this dataclass's
+    # percent+hours shape (not a dreame-only concept, just modeled here
+    # first) — every other field stays untouched, so existing dreame
+    # profiles are unaffected.
+    dust_bag_life: Prop | None = None
+    dust_bag_left_time: Prop | None = None
+    reset_dust_bag: Action | None = None
 
 
 @dataclass(frozen=True)

--- a/custom_components/xiaomi_vac/strings.json
+++ b/custom_components/xiaomi_vac/strings.json
@@ -187,6 +187,12 @@
       },
       "mop_life": {
         "name": "Mop life"
+      },
+      "dust_bag_life": {
+        "name": "Dust bag life"
+      },
+      "detergent_life": {
+        "name": "Detergent life"
       }
     },
     "select": {

--- a/custom_components/xiaomi_vac/translations/en.json
+++ b/custom_components/xiaomi_vac/translations/en.json
@@ -187,6 +187,12 @@
       },
       "mop_life": {
         "name": "Mop life"
+      },
+      "dust_bag_life": {
+        "name": "Dust bag life"
+      },
+      "detergent_life": {
+        "name": "Detergent life"
       }
     },
     "select": {

--- a/custom_components/xiaomi_vac/www/xiaomi-vac-card.js
+++ b/custom_components/xiaomi_vac/www/xiaomi-vac-card.js
@@ -91,7 +91,18 @@ const parseRGBA = (s) => {
 const MDI = {
   play: "mdi:play", pause: "mdi:pause", dock: "mdi:home-map-marker",
   locate: "mdi:map-marker-radius", fan: "mdi:fan", water: "mdi:water", map: "mdi:layers",
+  tools: "mdi:tools",
 };
+// Consumable sensors created by sensor.py (translation_key/icon/label kept in
+// sync with that file's XiaomiSensorDescription catalogue by hand — there is
+// no shared source of truth between the Python and JS sides of this card).
+const CONSUMABLES = [
+  ["main_brush_life", "mdi:broom", "Main brush"],
+  ["side_brush_life", "mdi:broom", "Side brush"],
+  ["filter_life", "mdi:air-filter", "Filter"],
+  ["dust_bag_life", "mdi:trash-can-outline", "Dust bag"],
+  ["detergent_life", "mdi:cup-water", "Detergent"],
+];
 // `charging` overlays a bolt — docked-and-charging reads identically to
 // docked-and-full otherwise (same grey accent, same fill bar).
 const batteryIcon = (p, charging) =>
@@ -115,6 +126,7 @@ const TOGGLE_DEFAULTS = {
   show_active_map: true,
   show_room_labels: true,
   allow_room_cleaning: true,
+  show_consumables: true,
 };
 
 class XiaomiVacCard extends HTMLElement {
@@ -157,6 +169,7 @@ class XiaomiVacCard extends HTMLElement {
       this._config.water || `select.${this._base()}_water_level`,
       this._config.fan || `select.${this._base()}_fan_speed`,
       this._activeMapEid(),
+      ...CONSUMABLES.map(([key]) => this._consumableEid(key)).filter(Boolean),
     ];
     return eids.some((e) => (a.states[e]) !== (b.states[e]));
   }
@@ -177,6 +190,26 @@ class XiaomiVacCard extends HTMLElement {
       if (found) { this._cachedMapEid = found; return found; }
     }
     return `select.${this._base()}_active_map`;   // fallback if registry lookup misses
+  }
+  // Same registry-lookup pattern as _activeMapEid(): the consumable sensors'
+  // entity_id can carry an area-name prefix HA auto-generates on first setup
+  // (e.g. "sensor.nappali_julika_neni_main_brush_life"), so guessing from the
+  // vacuum's own object_id would miss them — resolve by device_id + the
+  // translation_key sensor.py assigns each one instead.
+  _consumableEid(key) {
+    this._consumEidCache = this._consumEidCache || {};
+    if (this._consumEidCache[key] && this._st(this._consumEidCache[key])) return this._consumEidCache[key];
+    const ents = this._hass && this._hass.entities;
+    const vacEnt = ents && ents[this._config.vacuum];
+    const deviceId = vacEnt && vacEnt.device_id;
+    if (ents && deviceId) {
+      const found = Object.keys(ents).find((eid) =>
+        eid.startsWith("sensor.") &&
+        ents[eid].device_id === deviceId &&
+        ents[eid].translation_key === key);
+      if (found) { this._consumEidCache[key] = found; return found; }
+    }
+    return null;
   }
   getCardSize() { return 10; }   // ~50px/unit; the card is a fixed 520px
   connectedCallback() {
@@ -316,6 +349,24 @@ class XiaomiVacCard extends HTMLElement {
           box-shadow:0 6px 18px rgba(0,0,0,.25);opacity:0;transition:opacity .18s,transform .18s;
           pointer-events:none;white-space:nowrap;cursor:pointer;border:0}
         .roomtag.show{opacity:1;transform:translateX(-50%) translateY(-5px);pointer-events:auto}
+        /* accessory-status panel: a collapsible sheet above the tray, toggled by
+           the .act-consumables button — same frosted-glass treatment as .tray */
+        .consum-panel{position:absolute;left:14px;right:14px;bottom:74px;z-index:8;
+          background:color-mix(in srgb,var(--xv-card) 88%,transparent);
+          backdrop-filter:blur(22px) saturate(180%);-webkit-backdrop-filter:blur(22px) saturate(180%);
+          border:.5px solid color-mix(in srgb,var(--xv-ink) 8%,transparent);border-radius:16px;
+          box-shadow:0 8px 30px rgba(0,0,0,.18);padding:0 14px;max-height:0;overflow:hidden;
+          opacity:0;transform:translateY(6px);pointer-events:none;transition:opacity .18s,transform .18s,max-height .22s,padding .22s}
+        .consum-panel.show{opacity:1;transform:translateY(0);pointer-events:auto;max-height:280px;overflow:auto;padding:8px 14px}
+        .consum-row{display:flex;align-items:center;gap:10px;padding:7px 0}
+        .consum-row+.consum-row{border-top:1px solid color-mix(in srgb,var(--xv-ink) 8%,transparent)}
+        .consum-row ha-icon{--mdc-icon-size:20px;color:var(--xv-muted);flex:0 0 auto}
+        .consum-row .cn{flex:1 1 auto;font-size:13px;color:var(--xv-ink);font-weight:500}
+        .consum-row .cbar{width:56px;height:5px;border-radius:3px;
+          background:color-mix(in srgb,var(--xv-ink) 10%,transparent);overflow:hidden;flex:0 0 auto}
+        .consum-row .cbar i{display:block;height:100%;border-radius:3px}
+        .consum-row .cpct{width:34px;text-align:right;font-size:12px;font-weight:600;color:var(--xv-muted);flex:0 0 auto}
+        .act-consumables.on{background:var(--xv-accent);color:#fff}
         /* uniform segmented control (cf. the native climate card): every button
            equal width, the active action filled with the state accent */
         .tray{position:absolute;left:14px;right:14px;bottom:14px;z-index:7;
@@ -335,7 +386,7 @@ class XiaomiVacCard extends HTMLElement {
         .b:focus-visible{outline:2px solid var(--xv-accent);outline-offset:2px}
         /* narrow cards: shrink uniformly, then drop water before things spill */
         @container (max-width:340px){ .tray{gap:5px;padding:5px} .b{height:44px} .b ha-icon{--mdc-icon-size:22px} }
-        @container (max-width:240px){ .cyc-water{display:none} }
+        @container (max-width:240px){ .cyc-water{display:none} .act-consumables{display:none} }
         @media (prefers-reduced-motion:reduce){.track.anim{transition:none}.dot,.b{transition:none}
           .b:active{transform:none}}
       </style>
@@ -347,6 +398,7 @@ class XiaomiVacCard extends HTMLElement {
       <div class="dots"></div>
       <div class="toast"></div>
       <button class="roomtag"></button>
+      <div class="consum-panel"></div>
       <div class="tray">
         <button class="b act-start" title="Start / pause" aria-label="Start or pause"><ha-icon icon="${MDI.play}"></ha-icon></button>
         <button class="b act-dock" title="Return to dock" aria-label="Return to dock"><ha-icon icon="${MDI.dock}"></ha-icon></button>
@@ -354,6 +406,7 @@ class XiaomiVacCard extends HTMLElement {
         <button class="b cyc-fan" title="Suction" aria-label="Cycle suction level"><ha-icon icon="${MDI.fan}"></ha-icon></button>
         <button class="b cyc-water" title="Water level" aria-label="Cycle water level"><ha-icon icon="${MDI.water}"></ha-icon></button>
         <button class="b cyc-map" title="Active map" aria-label="Cycle active map"><ha-icon icon="${MDI.map}"></ha-icon></button>
+        <button class="b act-consumables" title="Accessories" aria-label="Show accessory status"><ha-icon icon="${MDI.tools}"></ha-icon></button>
       </div>`;
     this.appendChild(this._root);
 
@@ -374,6 +427,10 @@ class XiaomiVacCard extends HTMLElement {
       this._cycleSelect(this._config.water || `select.${this._base()}_water_level`);
     q(".cyc-map").onclick = () => this._cycleSelect(this._activeMapEid());
     q(".roomtag").onclick = () => this._cleanSelected();
+    q(".act-consumables").onclick = () => {
+      q(".consum-panel").classList.toggle("show");
+      q(".act-consumables").classList.toggle("on", q(".consum-panel").classList.contains("show"));
+    };
 
     this._setupSwipe();
     this._buildPages();
@@ -767,6 +824,26 @@ class XiaomiVacCard extends HTMLElement {
     const nm = q(".pg-img .nm");
     if (nm && vac) nm.textContent = vac.attributes.friendly_name || "Vacuum";
 
+    const showConsumables = this._enabled("show_consumables") &&
+      CONSUMABLES.some(([key]) => this._consumableEid(key));
+    q(".act-consumables").style.display = showConsumables ? "" : "none";
+    if (showConsumables) {
+      q(".consum-panel").innerHTML = CONSUMABLES.map(([key, icon, label]) => {
+        const eid = this._consumableEid(key);
+        const st = eid && this._st(eid);
+        const pct = st ? Number(st.state) : null;
+        const has = pct != null && !Number.isNaN(pct);
+        const clamped = has ? Math.max(0, Math.min(100, pct)) : 0;
+        const color = !has ? "var(--xv-muted)" : clamped < 20 ? "#e05252" : clamped < 50 ? "#e0a952" : "#4caf7d";
+        return `<div class="consum-row"><ha-icon icon="${icon}"></ha-icon><span class="cn">${esc(label)}</span>` +
+          `<span class="cbar"><i style="width:${clamped}%;background:${color}"></i></span>` +
+          `<span class="cpct" style="color:${has ? color : ""}">${has ? clamped + "%" : "—"}</span></div>`;
+      }).join("");
+    } else {
+      q(".consum-panel").classList.remove("show");
+      q(".act-consumables").classList.remove("on");
+    }
+
     this._updateAnim(state, vac && vac.attributes.model);
   }
 }
@@ -795,6 +872,7 @@ class XiaomiVacCardEditor extends HTMLElement {
           show_active_map: "Show active map control",
           show_room_labels: "Show room labels",
           allow_room_cleaning: "Allow room cleaning",
+          show_consumables: "Show accessory status button",
         }[s.name] || s.name);
       this._form.addEventListener("value-changed", (e) =>
         this.dispatchEvent(new CustomEvent("config-changed", { detail: { config: e.detail.value }, bubbles: true, composed: true })));
@@ -816,6 +894,7 @@ class XiaomiVacCardEditor extends HTMLElement {
       { name: "show_active_map", selector: { boolean: {} } },
       { name: "show_room_labels", selector: { boolean: {} } },
       { name: "allow_room_cleaning", selector: { boolean: {} } },
+      { name: "show_consumables", selector: { boolean: {} } },
     ];
   }
 }

--- a/tests/pure/helpers.py
+++ b/tests/pure/helpers.py
@@ -101,6 +101,7 @@ def load_sensor_module(monkeypatch: pytest.MonkeyPatch):
         native_unit_of_measurement: str | None = None
         state_class: str | None = None
         entity_category: str | None = None
+        icon: str | None = None
 
     class _SensorDeviceClass(SimpleNamespace):
         ENUM = "enum"

--- a/tests/pure/test_consumables.py
+++ b/tests/pure/test_consumables.py
@@ -37,6 +37,29 @@ def _ov42gl_profile(monkeypatch):
     return profiles_mod.XIAOMI_OV42GL
 
 
+def _ov21gl_profile(monkeypatch):
+    """Return the real xiaomi.ov21gl ModelProfile (no HA needed).
+
+    Same loader dance as `_ov42gl_profile` — kept separate rather than
+    parametrized so each call site stays a plain, greppable model lookup.
+    """
+    pkg_root = Path(__file__).resolve().parents[2] / "custom_components" / "xiaomi_vac"
+    pkg = ModuleType("xiaomi_vac")
+    pkg.__path__ = [str(pkg_root)]
+    sys.modules.setdefault("xiaomi_vac", pkg)
+
+    spec_pkg = ModuleType("xiaomi_vac.spec")
+    spec_pkg.__path__ = [str(pkg_root / "spec")]
+    sys.modules.setdefault("xiaomi_vac.spec", spec_pkg)
+
+    for name in list(sys.modules):
+        if name.startswith("xiaomi_vac.spec.") and "profiles" in name:
+            monkeypatch.delitem(sys.modules, name, raising=False)
+
+    profiles_mod = importlib.import_module("xiaomi_vac.spec.profiles.xiaomi")
+    return profiles_mod.XIAOMI_OV21GL
+
+
 # --- sensor.py: build_sensors() gating -------------------------------------
 def test_build_sensors_ov42gl_has_all_five_consumables(monkeypatch):
     sensor = load_sensor_module(monkeypatch)
@@ -132,6 +155,71 @@ def test_status_consumable_read_failure_does_not_break_status(monkeypatch):
     assert status.raw_status == 5
     assert status.main_brush_life == 87
     assert status.side_brush_life is None
+
+
+# --- xiaomi.ov21gl: mop-pad life instead of detergent, hardware-confirmed
+# by a real ov21gl owner (letitbe-dull/xiaomi-vac#20 comment, 2026-08-06) ---
+def test_build_sensors_ov21gl_has_mop_life_not_detergent(monkeypatch):
+    """ov21gl has no detergent/mop-solution-tank service — the mop PAD
+    itself carries the life-level instead. Confirms `mop_life` (previously
+    defined on DreameConsumablesCapability but never wired to any real
+    profile or polled by device.py) is now live end to end."""
+    sensor = load_sensor_module(monkeypatch)
+    profile = _ov21gl_profile(monkeypatch)
+
+    sensors = sensor.build_sensors(profile)
+    keys = {d.key for d in sensors}
+
+    assert {"main_brush_life", "side_brush_life", "filter_life", "dust_bag_life", "mop_life"} <= keys
+    assert "detergent_life" not in keys
+
+
+def test_status_returns_ov21gl_mop_life(monkeypatch):
+    device_mod = load_device_module(monkeypatch)
+    device = device_mod.IjaiVacuumDevice("host", "token", "xiaomi.vacuum.ov21gl")
+    status_prop = device.core.status
+    cons = device.profile.consumables
+
+    FakeMiotDevice.property_values = {
+        (status_prop.siid, status_prop.piid): 1,
+        (cons.main_brush_life.siid, cons.main_brush_life.piid): 80,
+        (cons.side_brush_life.siid, cons.side_brush_life.piid): 70,
+        (cons.filter_life.siid, cons.filter_life.piid): 60,
+        (cons.dust_bag_life.siid, cons.dust_bag_life.piid): 50,
+        (cons.mop_life.siid, cons.mop_life.piid): 40,
+    }
+
+    status = device.status()
+
+    assert status.main_brush_life == 80
+    assert status.side_brush_life == 70
+    assert status.filter_life == 60
+    assert status.dust_bag_life == 50
+    assert status.mop_life == 40
+    assert status.detergent_life is None
+
+
+def test_ov71gl_and_ov43gb_do_not_inherit_ov21gl_consumables(monkeypatch):
+    """ov71gl/ov43gb share ov21gl's CoreCapability via `replace()` but their
+    consumables siid/piid layout is unverified — must not silently pick up
+    ov21gl's hardware-confirmed table just because replace() copies fields
+    that aren't explicitly overridden."""
+    pkg_root = Path(__file__).resolve().parents[2] / "custom_components" / "xiaomi_vac"
+    pkg = ModuleType("xiaomi_vac")
+    pkg.__path__ = [str(pkg_root)]
+    sys.modules.setdefault("xiaomi_vac", pkg)
+    spec_pkg = ModuleType("xiaomi_vac.spec")
+    spec_pkg.__path__ = [str(pkg_root / "spec")]
+    sys.modules.setdefault("xiaomi_vac.spec", spec_pkg)
+    for name in list(sys.modules):
+        if name.startswith("xiaomi_vac.spec.") and "profiles" in name:
+            monkeypatch.delitem(sys.modules, name, raising=False)
+    profiles_mod = importlib.import_module("xiaomi_vac.spec.profiles.xiaomi")
+
+    assert profiles_mod.XIAOMI_OV71GL.consumables is None
+    assert profiles_mod.XIAOMI_OV43GB.consumables is None
+    assert profiles_mod.XIAOMI_C107.consumables is None
+    assert profiles_mod.XIAOMI_D101.consumables is None
 
 
 def test_status_consumables_not_polled_for_profile_without_them(monkeypatch):

--- a/tests/pure/test_consumables.py
+++ b/tests/pure/test_consumables.py
@@ -1,0 +1,151 @@
+"""Pure tests for the consumable-life sensors (main/side brush, filter, dust
+bag, detergent) added on top of `DreameConsumablesCapability` for
+`xiaomi.ov42gl` — covers `sensor.py`'s `build_sensors()` gating and
+`device.py`'s `IjaiVacuumDevice.status()` actually polling+returning them.
+
+No homeassistant install required — see tests/pure/helpers.py.
+"""
+from __future__ import annotations
+
+import importlib
+import sys
+from dataclasses import replace
+from pathlib import Path
+from types import ModuleType
+
+import pytest
+
+from .helpers import FakeMiotDevice, load_device_module, load_sensor_module
+
+
+def _ov42gl_profile(monkeypatch):
+    """Return the real xiaomi.ov42gl ModelProfile (no HA needed)."""
+    pkg_root = Path(__file__).resolve().parents[2] / "custom_components" / "xiaomi_vac"
+    pkg = ModuleType("xiaomi_vac")
+    pkg.__path__ = [str(pkg_root)]
+    sys.modules.setdefault("xiaomi_vac", pkg)
+
+    spec_pkg = ModuleType("xiaomi_vac.spec")
+    spec_pkg.__path__ = [str(pkg_root / "spec")]
+    sys.modules.setdefault("xiaomi_vac.spec", spec_pkg)
+
+    for name in list(sys.modules):
+        if name.startswith("xiaomi_vac.spec.") and "profiles" in name:
+            monkeypatch.delitem(sys.modules, name, raising=False)
+
+    profiles_mod = importlib.import_module("xiaomi_vac.spec.profiles.xiaomi")
+    return profiles_mod.XIAOMI_OV42GL
+
+
+# --- sensor.py: build_sensors() gating -------------------------------------
+def test_build_sensors_ov42gl_has_all_five_consumables(monkeypatch):
+    sensor = load_sensor_module(monkeypatch)
+    profile = _ov42gl_profile(monkeypatch)
+
+    sensors = sensor.build_sensors(profile)
+    keys = {d.key for d in sensors}
+
+    assert {"main_brush_life", "side_brush_life", "filter_life", "dust_bag_life", "detergent_life"} <= keys
+
+
+def test_build_sensors_profile_without_consumables_omits_them(monkeypatch):
+    """A profile whose `consumables` isn't the percent+hours-shaped
+    DreameConsumablesCapability (e.g. None, or ijai's own different shape)
+    must not produce any of these five sensors."""
+    sensor = load_sensor_module(monkeypatch)
+    profile = _ov42gl_profile(monkeypatch)
+    bare_profile = replace(profile, consumables=None)
+
+    sensors = sensor.build_sensors(bare_profile)
+    keys = {d.key for d in sensors}
+
+    assert keys.isdisjoint({"main_brush_life", "side_brush_life", "filter_life", "dust_bag_life", "detergent_life"})
+
+
+def test_build_sensors_partial_consumables_only_supported_ones(monkeypatch):
+    """If only some consumable props are set on the profile (e.g. no dust
+    bag on a mop-only model), only the sensors with a real prop should be
+    built — matches the same per-field `supported_fn` gating pattern
+    `battery`/`status` already use."""
+    sensor = load_sensor_module(monkeypatch)
+    profile = _ov42gl_profile(monkeypatch)
+    # Import AFTER load_sensor_module: it reloads xiaomi_vac.spec.types fresh
+    # into sys.modules, so importing DreameConsumablesCapability any earlier
+    # would grab a stale module instance — isinstance() against sensor.py's
+    # own (later-reloaded) class would then silently always be False.
+    from xiaomi_vac.spec.types import DreameConsumablesCapability, Prop
+    partial = replace(profile, consumables=DreameConsumablesCapability(
+        main_brush_life=Prop(12, 1), side_brush_life=None,
+        filter_life=None, dust_bag_life=None, detergent_life=None,
+    ))
+
+    sensors = sensor.build_sensors(partial)
+    keys = {d.key for d in sensors}
+
+    assert "main_brush_life" in keys
+    assert keys.isdisjoint({"side_brush_life", "filter_life", "dust_bag_life", "detergent_life"})
+
+
+# --- device.py: IjaiVacuumDevice.status() actually polling them ------------
+def test_status_returns_all_consumable_life_values(monkeypatch):
+    device_mod = load_device_module(monkeypatch)
+    device = device_mod.IjaiVacuumDevice("host", "token", "xiaomi.vacuum.ov42gl")
+    status_prop = device.core.status
+    cons = device.profile.consumables
+
+    FakeMiotDevice.property_values = {
+        (status_prop.siid, status_prop.piid): 5,
+        (cons.main_brush_life.siid, cons.main_brush_life.piid): 87,
+        (cons.side_brush_life.siid, cons.side_brush_life.piid): 62,
+        (cons.filter_life.siid, cons.filter_life.piid): 45,
+        (cons.dust_bag_life.siid, cons.dust_bag_life.piid): 90,
+        (cons.detergent_life.siid, cons.detergent_life.piid): 33,
+    }
+
+    status = device.status()
+
+    assert status.main_brush_life == 87
+    assert status.side_brush_life == 62
+    assert status.filter_life == 45
+    assert status.dust_bag_life == 90
+    assert status.detergent_life == 33
+
+
+def test_status_consumable_read_failure_does_not_break_status(monkeypatch):
+    """One consumable prop failing (e.g. transient read error) must not
+    raise or blank out the rest of the status — only status itself is
+    required (matches the existing ijai behaviour in test_device_status.py's
+    test_status_tolerates_optional_prop_none)."""
+    device_mod = load_device_module(monkeypatch)
+    device = device_mod.IjaiVacuumDevice("host", "token", "xiaomi.vacuum.ov42gl")
+    status_prop = device.core.status
+    cons = device.profile.consumables
+
+    FakeMiotDevice.property_values = {
+        (status_prop.siid, status_prop.piid): 5,
+        (cons.main_brush_life.siid, cons.main_brush_life.piid): 87,
+        # side_brush/filter/dust_bag/detergent simply absent -> None, no batch failure
+    }
+
+    status = device.status()
+
+    assert status.raw_status == 5
+    assert status.main_brush_life == 87
+    assert status.side_brush_life is None
+
+
+def test_status_consumables_not_polled_for_profile_without_them(monkeypatch):
+    """A profile with no DreameConsumablesCapability (e.g. plain ijai) must
+    not attempt to read any consumable prop at all — confirms the
+    isinstance-gated poll list in device.py, not just that the result comes
+    back None."""
+    device_mod = load_device_module(monkeypatch)
+    device = device_mod.IjaiVacuumDevice("host", "token", "ijai.vacuum.v17")
+    status_prop = device.core.status
+    FakeMiotDevice.property_values = {(status_prop.siid, status_prop.piid): 5}
+
+    status = device.status()
+
+    assert status.main_brush_life is None
+    assert status.dust_bag_life is None
+    assert status.detergent_life is None


### PR DESCRIPTION
## Summary

Independent of #20 (map rendering) — this is a separate, orthogonal feature touching a different part of the integration (sensor/device layer, not the map). Confirmed model-specific: read straight off a real H50 Pro's own cached MIoT spec, not extended to other `xiaomi.ov*` profiles since those haven't been hardware-verified against this same siid/piid layout.

## What's added

`DreameConsumablesCapability` (existing dataclass, previously only used by dreame profiles) gained two more fields — `dust_bag_life`/`dust_bag_left_time` — since the H50 Pro's dust-bag service turned out to share the exact same percent+hours shape every other consumable on this dataclass already uses, just on its own siid. `xiaomi.ov42gl`'s profile now sets `consumables=` for all five: main brush (siid 12), side brush (siid 13), filter (siid 14), detergent/mop-solution tank (siid 18), dust bag (siid 19) — each `life` prop is percent, each `left_time` prop is hours (left_time props aren't polled yet, no consumer needs them; kept on the profile for a future sensor if wanted).

`device.py`'s `status()` now polls the life-level prop for each consumable the profile actually declares (`isinstance(profile.consumables, DreameConsumablesCapability)` gate — a profile without this capability shape, e.g. plain ijai, polls none of them and the fields stay `None`, matching the existing lean-core convention for not-yet-wired data).

`sensor.py` gets five new `SensorEntityDescription`s (diagnostic category, percent unit), each gated by its own `supported_fn` so a profile missing one specific consumable (e.g. no dust bag on a mop-only model) only builds sensors for what it actually has — same per-field pattern `battery` already used, just factored into a small `_has_consumable()` helper since there are now five of these instead of one.

`www/xiaomi-vac-card.js` (the bundled "Atlas" card) gets an optional accessory-status panel: a small tools-icon button in the control tray that expands a sheet listing each consumable with a percent bar (colored by threshold: red <20%, amber <50%, green otherwise). Entities are resolved by device_id + translation_key (same pattern the card's existing active-map selector uses), not by guessing an entity_id from the vacuum's object_id, so it doesn't break if HA auto-prefixes an area name. New `show_consumables` config toggle (default true) in case someone wants it hidden.

## Testing

`tests/pure`: **743/743 passing** (737 pre-existing + 6 new in `tests/pure/test_consumables.py`, covering `sensor.py`'s per-field consumable gating — full set, none, and a partial-capability profile — and `device.py`'s `status()` actually polling+returning all five values, plus that a profile without this capability shape polls none of them). `tests/pure/helpers.py`'s `SensorEntityDescription` test stub gained an `icon` field to match the real HA dataclass — the new sensors use `icon=` and the existing stub didn't have it (nothing before this used it), a one-line, backward-compatible addition to the shared test helper.

Not independently verified against any other model in the family — this PR only claims `xiaomi.ov42gl`, deliberately not extended to `ov21gl`/`ov31gl`/etc. without hardware to confirm the same siid layout holds.
