### PR TITLE
Route xiaomi d109gl family to the xiaomi JSON map parser

### DIFF
--- a/custom_components/xiaomi_vac/map_parsers.py
+++ b/custom_components/xiaomi_vac/map_parsers.py
@@ -70,8 +70,22 @@ def dreame_decrypt_cloud_blob(raw: bytes, enckey: str) -> bytes:
 # would hand a JSON blob to the ijai protobuf parser even if the URL fetch
 # succeeded. Needs a live camera-entity retest to confirm; ov43gb is added on
 # spec-family grounds only (no real device to test against yet).
+#
+# c107/d101/d102ev/d102gl/d109gl (2026-08-13): same siid=2 core layout as
+# ov21gl, so the same map family. d109gl is hardware-confirmed: before this
+# fix the ijai fallback produced "Could not decrypt map at slot 0: Data must
+# be aligned to block boundary in ECB mode" every cycle (map camera stuck
+# unavailable); routing to the xiaomi JSON parser fixes it (decrypt key comes
+# from model[-16:], see xiaomi_json_decrypt.py) and the live map + card work.
+# c107/d101/d102ev/d102gl share the identical replace(XIAOMI_C107, ...)
+# profile layout and are added on spec-family grounds only (no hardware yet).
 _XIAOMI_JSON_MAP_PROFILES = frozenset({
     "xiaomi.e101gb",
+    "xiaomi.d109gl", #confirmed
+    "xiaomi.c107",
+    "xiaomi.d101",
+    "xiaomi.d102ev",
+    "xiaomi.d102gl",
     "xiaomi.ov21gl",
     "xiaomi.ov31gl",
     "xiaomi.ov42gl",

--- a/tests/pure/test_map.py
+++ b/tests/pure/test_map.py
@@ -173,6 +173,21 @@ def test_dreame_phase1_hub_profiles_route_to_dreame_parser(model):
     assert profile.map is not None
     assert map_parsers.parser_key(profile) == "dreame"
 
+@pytest.mark.parametrize(
+    "model",
+    [
+        "xiaomi.vacuum.d109gl",
+        "xiaomi.vacuum.c107",
+        "xiaomi.vacuum.d101",
+        "xiaomi.vacuum.d102ev",
+        "xiaomi.vacuum.d102gl",
+    ],
+)
+def test_d109gl_family_routes_to_xiaomi_json_parser(model):
+    from spec.registry import get_profile
+    profile = get_profile(model)
+    assert profile is not None
+    assert map_parsers.parser_key(profile) == "xiaomi"
 
 def test_has_ijai_grid_only_ijai():
     assert map_parsers.has_ijai_grid("ijai") is True


### PR DESCRIPTION
## What
Route the xiaomi.c107/d10x family (d109gl confirmed on real hardware;
c107/d101/d102ev/d102gl by spec-family resemblance, same replace(XIAOMI_C107, …)
layout) to the xiaomi JSON map parser instead of the ijai fallback.

## Symptom (xiaomi.vacuum.d109gl, Home Assistant docker)
Control works fine; map camera permanently unavailable. Debug log:
- `Map key inputs: brand=ijai ... model=xiaomi.vacuum.d109gl`
- `Could not decrypt map at slot 0: Data must be aligned to block boundary in ECB mode`
- `Map cycle: slot keys=['B', 'B'] active_id=0 maps_listed=0`

## Fix
Adding the models to `_XIAOMI_JSON_MAP_PROFILES` makes the coordinator use
`decrypt_xiaomi_json_map` (verified model-agnostic: AES key from model[-16:]).
Result: `Map key inputs: brand=xiaomi` + `Serving map ... (live+cached)`.

## Testing
- d109gl: map renders live + card works, confirmed on real device.
- Sibling models added on spec-family grounds only (same profile layout) —
  mirroring the ov43gb precedent. Untested on hardware; please keep an eye.
- Added unit test for the routing.