### PR TITLE
Add room-clean support for ijai.vacuum.v10, fix wifi_sn parsing bug

### DIFF
--- a/custom_components/xiaomi_vac/device.py
+++ b/custom_components/xiaomi_vac/device.py
@@ -334,9 +334,14 @@ class IjaiVacuumDevice:
         except Exception as err:  # noqa: BLE001
             _LOGGER.debug("wifi_sn: siid 7/piid 45 fallback read failed: %s", err)
             return None
-        for part in str(raw).split(","):
+        # The raw value is a bracketed list rendered as a string (e.g.
+        # '[0,0,...,"XXXX"]'), not real JSON. Strip the outer brackets first
+        # so the first and last elements do not retain a stray '[' / ']'
+        # that would otherwise fail the isalnum() check below (serial in
+        # last list position never matched, e.g. ijai.vacuum.v10).
+        for part in str(raw).strip("[]").split(","):
             # The serial sits before an optional ";<uid>" suffix on siid 7/piid 45.
-            p = part.replace('"', "").split(";")[0]
+            p = part.replace('"', "").split(";")[0].strip()
             if _is_wifi_sn(p) and p.isalnum():
                 return p
         _LOGGER.debug("wifi_sn: siid 7/piid 45 value %r had no matching serial part", raw)

--- a/custom_components/xiaomi_vac/spec/profiles/ijai.py
+++ b/custom_components/xiaomi_vac/spec/profiles/ijai.py
@@ -533,6 +533,12 @@ IJAI_V10 = ModelProfile(
         arrange_room=Action(10, 8, in_piids=(6, 11, 13), out_piids=(6, 7, 18)),
         split_room=Action(10, 9, in_piids=(6, 9, 12, 13), out_piids=(6, 7, 18)),
     ),
+    room_clean=RoomCleanCapability(
+        clean_room_ids=Prop(7, 24),
+        clean_room_mode=Prop(7, 25),
+        clean_room_oper=Prop(7, 26),
+        set_room_clean=Action(7, 3, in_piids=(24, 25, 26)),
+    ),
     schedule=ScheduleCapability(
         service=8,
         add=Action(8, 1, in_piids=(1, 2, 3, 4, 5, 6, 11, 14, 12, 7, 8, 9, 17, 19)),


### PR DESCRIPTION
## Summary
Two related fixes that together get `ijai.vacuum.v10` past setup, found while getting the integration working on a live pair of v10 units.

## 1. IJAI_V10 profile missing room_clean
`is_supported()` gates onboarding on `card_baseline_gaps()`, which requires a populated `room_clean` capability. `IJAI_V10`'s `ModelProfile` didn't set one, so config flow aborted with `unsupported_model` — even though the device's own MIoT spec exposes exactly what's needed: `siid=7/aiid=3` (`set-room-clean`), taking `in_piids (24, 25, 26)`. That's the identical shape already used for `IJAI_V1`, `IJAI_V13`, `IJAI_V14`/`15`, etc. in this same file. Added the matching `RoomCleanCapability` block, confirmed against the device's exported spec (`urn:miot-spec-v2:device:vacuum:0000A006:ijai-v10:1`).

## 2. wifi_sn parsing drops serials in the last list position
`get_wifi_sn()`'s `siid=7/piid=45` fallback does `str(raw).split(",")` without stripping the outer `[`/`]` first. The raw value is a bracketed list rendered as a string, e.g.:
```
[0,0,0,2,0,0,-7200,27,1648,"3448226V2201B07036"]
```
When the serial is the *last* element (as on v10), the naive split leaves a trailing `]` attached, which fails the `.isalnum()` check even though the value otherwise matches `_is_wifi_sn()`. The coordinator then raises `Missing map key input wifi_sn: could not read it live or from storage` and the map camera never builds. Stripping the brackets before splitting fixes this regardless of where in the list the serial lands.

## Testing
Both verified live on two `ijai.vacuum.v10` units (HA 2026.8.1, on top of the #22 Pillow fix):
- Config flow now completes and creates entities instead of aborting with `unsupported_model`.
- Debug log confirms `wifi_sn` is now read correctly: `Map key inputs: brand=ijai wifi_sn='3448226V2201B07036' mac=B4:60:ED:0D:F2:D1 ...` (previously always empty for this model).

**Not yet confirmed:** the map camera itself still fails to produce an image after these two fixes — see the issue I'm filing separately, since that looks like a distinct problem (possibly stale/incomplete cloud map data rather than a code bug) and I don't want to claim it in this PR before it's actually verified working.